### PR TITLE
feat: docs polish and spec hygiene (spec 006)

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -9,6 +9,8 @@ Auto-generated from all feature plans. Last updated: 2026-03-30
 - N/A — static files only; no database, no server state (003-get-tilde-sh-site)
 - TypeScript 5.x / Node.js 22.x (CLI); Astro 5.x + Starlight (docs site); Bash (install script); HTML + Tailwind CDN (install page) + Ink (React terminal UI), Astro, @astrojs/starlight, Vites (005-ui-branding-consolidation)
 - N/A — no database; config is JSON files on disk (005-ui-branding-consolidation)
+- TypeScript 5.4, Node.js 20 LTS, ESM (`"type": "module"`) + Ink (React terminal UI), Zod (config schema validation), `node:fs`, `node:url`, `node:path` (006-docs-polish-spec-hygiene)
+- File system only — `docs/`, `docs/design/`, `src/`, `specs/` (006-docs-polish-spec-hygiene)
 
 - Node.js 20 LTS, TypeScript 5.4+ + Ink 4, React 18, ink-select-input, ink-text-input, ink-spinner, (001-mvp-macos-bootstrap)
 
@@ -28,9 +30,9 @@ npm test && npm run lint
 Node.js 20 LTS, TypeScript 5.4+: Follow standard conventions
 
 ## Recent Changes
+- 006-docs-polish-spec-hygiene: Added TypeScript 5.4, Node.js 20 LTS, ESM (`"type": "module"`) + Ink (React terminal UI), Zod (config schema validation), `node:fs`, `node:url`, `node:path`
 - 005-ui-branding-consolidation: Added TypeScript 5.x / Node.js 22.x (CLI); Astro 5.x + Starlight (docs site); Bash (install script); HTML + Tailwind CDN (install page) + Ink (React terminal UI), Astro, @astrojs/starlight, Vites
 - 003-get-tilde-sh-site: Added Bash 5+ (install script); Astro 4+ with Starlight (docs site); + Astro 4, `@astrojs/starlight`, Node.js 20+ (docs build only);
-- 002-cli-polish-resilience: Added Node.js 20 LTS, TypeScript 5.4+ + Ink 6.8, React 18, Zod 4.3 (config schema + validation), execa 9.6
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches: ['**']
     paths-ignore:
-      - 'docs/**'
       - 'specs/**'
       - 'terraform/**'
-      - '**/*.md'
+      - '*.md'
       - '.specify/**'
   pull_request:
     branches: [main]
@@ -37,6 +36,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Validate config doc example
+        run: npm run validate:config-doc
 
       - name: Unit tests
         run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <div align="center">
+  <img src="docs/design/tilde-logo-variation.svg" alt="tilde" width="160"/>
+  <br/><br/>
   <img src="docs/banner.svg" alt="tilde — developer environment bootstrap" width="560"/>
 
   [![CI](https://github.com/jwill824/tilde/actions/workflows/ci.yml/badge.svg)](https://github.com/jwill824/tilde/actions/workflows/ci.yml)
@@ -34,6 +36,7 @@ npx @jwill824/tilde
 - **Idempotent** — safe to re-run; skips anything already correctly configured
 - **Plugin architecture** — every integration (package manager, version manager, secrets backend) is swappable
 - **Checkpoint / resume** — interrupted mid-wizard? Pick up where you left off
+- 📄 [Configuration reference](docs/config-format.md)
 
 ---
 

--- a/docs/config-format.md
+++ b/docs/config-format.md
@@ -1,0 +1,346 @@
+# tilde Configuration Format
+
+> JSON Schema: `https://thingstead.io/tilde/config-schema/v1.json`  
+> Schema version: `1`
+
+`tilde.config.json` is the declarative configuration file for tilde. It describes your entire developer environment so that `tilde` can reproduce it on any machine.
+
+---
+
+## Annotated Example
+
+The following complete example shows every field with inline explanations. (Standard JSON does not support `//` comments — strip them before using this example as a real config file.)
+
+```json
+{
+  "$schema": "https://thingstead.io/tilde/config-schema/v1.json", // enables editor autocomplete and validation
+  "schemaVersion": 1,          // version of the config file format — always 1 for now
+  "version": "1",              // tilde configuration format revision — always "1"
+  "os": "macos",               // target OS — only macOS is currently supported
+  "shell": "zsh",              // your primary shell: "zsh", "bash", or "fish"
+  "packageManager": "homebrew", // package manager — only Homebrew is currently supported
+  "workspaceRoot": "~/Developer", // root directory where all your projects live
+  "dotfilesRepo": "~/Developer/personal/dotfiles", // path to your dotfiles repository
+  "secretsBackend": "1password", // where should tilde store and retrieve your secrets? — "1password", "keychain", or "env-only"
+  "versionManagers": [
+    { "name": "vfox" }          // version managers to install: "vfox", "nvm", "pyenv", or "sdkman"
+  ],
+  "languages": [
+    { "name": "node", "version": "22.0.0", "manager": "vfox" }, // language runtimes; "manager" must match a name in versionManagers
+    { "name": "python", "version": "3.12.0", "manager": "vfox" }
+  ],
+  "tools": ["ripgrep", "fzf", "bat"], // Homebrew packages to install (optional)
+  "configurations": {
+    "git": true,           // write ~/.gitconfig and per-context gitconfigs
+    "vscode": true,        // write VS Code settings per context
+    "aliases": false,      // write shell aliases file
+    "osDefaults": false,   // apply macOS system preferences from defaults.json
+    "direnv": true         // install direnv and generate .envrc files for auto context-switching
+  },
+  "accounts": [
+    {
+      "service": "npm",                           // service name (optional, can add multiple)
+      "identifier": "jane@example.com",           // username or email for this service
+      "secretRef": "op://Personal/NPM/token"      // secrets backend reference for credentials
+    }
+  ],
+  "contexts": [
+    {
+      "label": "personal",                    // unique name for this context
+      "path": "~/Developer/personal",         // filesystem path this context applies to
+      "git": {
+        "name": "Jane Doe",                   // your git author name in this context
+        "email": "jane@example.com"           // your git author email — must be a valid address
+      },
+      "github": { "username": "janedoe" },    // your GitHub username for the gh CLI (optional)
+      "authMethod": "gh-cli",                 // how will you authenticate to GitHub in this context? — "gh-cli", "https", or "ssh"
+      "envVars": [],                          // environment variables to load when you're working in this context (use your secrets backend references — not raw tokens)
+      "vscodeProfile": "personal",            // which VS Code profile should be active in this context? (optional)
+      "isDefault": true                       // is this the context tilde should use when you're not inside any named workspace path? (optional)
+    },
+    {
+      "label": "work",
+      "path": "~/Developer/work",
+      "git": {
+        "name": "Jane Doe",
+        "email": "jane@acme.com"
+      },
+      "github": { "username": "jane-acme" },
+      "authMethod": "ssh",
+      "envVars": [
+        { "key": "NPM_TOKEN", "value": "op://Work/NPM/token" } // use backend references, not raw values
+      ],
+      "vscodeProfile": "work",
+      "isDefault": false
+    }
+  ]
+}
+```
+
+---
+
+## Top-Level Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `$schema` | string | no | JSON Schema URL for editor tooling (autocomplete, inline validation) |
+| `schemaVersion` | number | **yes** | Version of the config file format — always `1` for current tilde |
+| `version` | `"1"` | **yes** | tilde configuration format revision — always `"1"` |
+| `os` | `"macos"` | **yes** | Target OS — only macOS is currently supported |
+| `shell` | one of `"zsh"`, `"bash"`, `"fish"` | **yes** | Your primary shell |
+| `packageManager` | `"homebrew"` | **yes** | Package manager — only Homebrew is currently supported |
+| `versionManagers` | list of VersionManager | **yes** | Version managers to install |
+| `languages` | list of Language | **yes** | Language runtimes to install |
+| `workspaceRoot` | string | **yes** | Root directory for all your projects (e.g. `~/Developer`) |
+| `dotfilesRepo` | string | **yes** | Path to your dotfiles repository — must be an absolute path or start with `~/` |
+| `contexts` | list of DeveloperContext | **yes** | One or more developer contexts (at least one required) |
+| `tools` | list of strings | no | Homebrew packages to install |
+| `configurations` | ConfigurationDomains | **yes** | Feature flags for which dotfiles and integrations tilde manages |
+| `accounts` | list of Account | no | Service account references |
+| `secretsBackend` | one of `"1password"`, `"keychain"`, `"env-only"` | **yes** | Where should tilde store and retrieve your secrets? |
+
+---
+
+## VersionManager
+
+```json
+{ "name": "vfox" }
+```
+
+| Field | Type | Valid values |
+|-------|------|-------------|
+| `name` | string | `"vfox"`, `"nvm"`, `"pyenv"`, `"sdkman"` |
+
+---
+
+## Language
+
+```json
+{ "name": "node", "version": "22.0.0", "manager": "vfox" }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Language identifier (e.g. `node`, `python`, `java`) |
+| `version` | string | Version string (e.g. `22.0.0`, `3.12.0`) |
+| `manager` | string | Must match one of the names in your `versionManagers` list |
+
+> **Validation**: Every language's `manager` value must reference a manager listed in `versionManagers`.
+
+---
+
+## DeveloperContext
+
+A context maps a filesystem path to a git identity and optional tooling configuration.
+
+```json
+{
+  "label": "work",
+  "path": "~/Developer/work",
+  "git": { "name": "Jane Doe", "email": "jane@acme.com" },
+  "github": { "username": "jane-acme" },
+  "authMethod": "ssh",
+  "envVars": [
+    { "key": "NPM_TOKEN", "value": "op://Work/NPM/token" }
+  ],
+  "vscodeProfile": "work",
+  "isDefault": false
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `label` | string | **yes** | Unique name for this context — no two contexts may share a label |
+| `path` | string | **yes** | Workspace path this context applies to |
+| `git.name` | string | **yes** | Git author name in this context |
+| `git.email` | string | **yes** | Git author email — must be a valid email address |
+| `github.username` | string | no | GitHub username for the `gh` CLI |
+| `authMethod` | one of `"gh-cli"`, `"https"`, `"ssh"` | **yes** | How will you authenticate to GitHub in this context? — `gh-cli`: use the GitHub CLI; `https`: HTTPS with a credential helper; `ssh`: SSH key pair |
+| `envVars` | list of EnvVarReference | no | Environment variables to load when you're working in this context (use your secrets backend references — not raw tokens) |
+| `vscodeProfile` | string | no | Which VS Code profile should be active in this context? |
+| `isDefault` | boolean | no | Is this the context tilde should use when you're not inside any named workspace path? |
+
+> **Validation**: Context labels must be unique across all contexts.
+
+---
+
+## EnvVarReference
+
+Environment variables **must** use secrets backend references — raw secrets are rejected at validation time.
+
+```json
+{ "key": "GITHUB_TOKEN", "value": "op://Personal/GitHub/token" }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Environment variable name |
+| `value` | string | Backend reference (e.g. `op://Vault/Item/Field`) or plain value |
+
+> **Security**: Values beginning with `ghp_`, `sk-`, `AKIA`, or `xox[bp]-` are **blocked** — use a secrets backend reference instead.
+
+---
+
+## ConfigurationDomains
+
+Controls which dotfiles and integrations tilde manages:
+
+```json
+{
+  "git": true,
+  "vscode": true,
+  "aliases": false,
+  "osDefaults": false,
+  "direnv": true
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `git` | boolean | Write `~/.gitconfig` and per-context gitconfigs |
+| `vscode` | boolean | Write VS Code settings per context |
+| `aliases` | boolean | Write shell aliases file |
+| `osDefaults` | boolean | Should tilde apply macOS system preferences defined in your dotfiles? |
+| `direnv` | boolean | Should tilde manage `.envrc` files for automatic context switching? |
+
+---
+
+## Account
+
+```json
+{ "service": "npm", "identifier": "jane@example.com", "secretRef": "op://Personal/NPM/token" }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `service` | string | **yes** | Service name (e.g. `npm`, `docker`) |
+| `identifier` | string | **yes** | Username or email for this service |
+| `secretRef` | string | no | Secrets backend reference for credentials |
+
+---
+
+## Secrets Backends
+
+| Value | Description |
+|-------|-------------|
+| `"1password"` | Use 1Password CLI (`op`) — reference secrets as `op://Vault/Item/Field` |
+| `"keychain"` | Use macOS Keychain |
+| `"env-only"` | No secrets backend; environment variables only (local non-tracked file) |
+
+---
+
+## File Locations
+
+When tilde writes dotfiles, they go into your `dotfilesRepo`:
+
+| Dotfile | Location in repo |
+|---------|-----------------|
+| Global `.gitconfig` | `git/.gitconfig` |
+| Per-context gitconfig | `git/.gitconfig-{label}` |
+| `.zshrc` | `shell/.zshrc` |
+| VS Code settings | `vscode/{label}-settings.json` |
+| macOS defaults | `defaults.json` (read from repo) |
+
+Symlinks are created from `~/.gitconfig` → `{dotfilesRepo}/git/.gitconfig`, etc.
+
+---
+
+## Environment Variables
+
+| Variable | Equivalent flag | Description |
+|----------|----------------|-------------|
+| `TILDE_CONFIG` | `--config` | Path to `tilde.config.json` |
+| `TILDE_CI` | `--ci` | Non-interactive mode — set to `1` or `true` |
+| `TILDE_NO_COLOR` | — | Disable color output |
+| `TILDE_STATE_DIR` | — | Override `~/.tilde/` state directory |
+
+---
+
+## Schema Versioning and Migration
+
+Every `tilde.config.json` written by tilde includes a `schemaVersion` integer field:
+
+```json
+{
+  "schemaVersion": 1,
+  ...
+}
+```
+
+### What `schemaVersion` means
+
+The `schemaVersion` field records the version of the config file format. tilde reads this field at startup to decide whether the config needs to be updated before use.
+
+| Value | Meaning |
+|-------|---------|
+| `1` | Inaugural schema — current version |
+
+### v1: Inaugural schema
+
+v1 is the first schema version. No prior versions exist. Any config already at `schemaVersion: 1` requires no migration — tilde will load and use it as-is.
+
+### How the migration runner works
+
+When tilde loads a config whose `schemaVersion` is lower than the current version it supports, it automatically:
+
+1. Detects the `schemaVersion` on load
+2. Applies all applicable migration steps in order (oldest to newest)
+3. Writes the updated config back to disk atomically (via a temp file + rename)
+4. Notifies you that your config was updated
+
+Migration steps are **additive and non-destructive** — they add defaults for new fields and rename deprecated fields, but they never remove user-provided values or alter data you have set intentionally.
+
+**If migration fails**: tilde warns you, preserves your original config file unmodified, and offers to re-run the setup wizard so you can re-enter your preferences safely.
+
+### Forward-version handling
+
+If tilde reads a config whose `schemaVersion` is **higher** than the installed tilde version supports, tilde will:
+
+1. Warn you that your config was written by a newer version of tilde
+2. Open the config in **read-only mode** — no changes will be written to disk
+3. Prompt you to upgrade tilde to the latest version
+
+### Future migration template skeleton
+
+The following is the pattern that future migration steps will follow. It is provided here as a reference for contributors adding v2 or later migrations. *(No v2 migration exists yet.)*
+
+```typescript
+// Future migration skeleton — not active code
+// migrations/v2.ts
+
+export const migrateV1toV2 = (config: unknown): unknown => {
+  const c = config as Record<string, unknown>;
+  // Example: rename a deprecated field
+  // if ('oldFieldName' in c) {
+  //   c['newFieldName'] = c['oldFieldName'];
+  //   delete c['oldFieldName'];
+  // }
+  // Example: add a new field with a default value
+  // c['newFeature'] ??= false;
+  c['schemaVersion'] = 2;
+  return c;
+};
+```
+
+---
+
+## CLI Reference
+
+### `--reconfigure`
+
+Re-open the full configuration wizard with all existing values pre-populated as defaults:
+
+```sh
+tilde --reconfigure
+```
+
+**Behaviour**:
+- Loads the existing `tilde.config.json` from the path specified by `--config` (or the default location)
+- Opens the full 14-step wizard with every field pre-filled from the stored config
+- On completion, atomically overwrites the config file with the updated values
+- On early exit (Ctrl-C or Cancel), the original config file is **not modified**
+
+**Error cases**:
+- **No config found**: tilde exits with a message directing you to run `tilde` (without `--reconfigure`) to create your initial configuration
+- **Invalid config**: tilde displays each invalid field by name before opening the wizard; those fields use their wizard defaults. All other fields remain pre-populated from the stored config.
+- **Early exit** (Escape or Cancel): the original config file is **not modified**. tilde exits with code `5` to indicate user cancellation.

--- a/docs/design/tilde-logo-variation.svg
+++ b/docs/design/tilde-logo-variation.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60" fill="none" role="img">
+  <title>tilde</title>
+  <!-- Dark background -->
+  <rect width="120" height="60" fill="#030712" rx="8"/>
+  <!-- Tilde wave mark (bezier) -->
+  <path d="M4 22 C8 10, 14 10, 16 22 C18 34, 24 34, 28 22"
+        stroke="#4ade80" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <!-- Tilde character glyph -->
+  <text x="38" y="38"
+        font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace"
+        font-size="28" font-weight="600" fill="#4ade80">~</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:contract": "vitest run --config vitest.contract.config.ts",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "validate:config-doc": "npx tsx scripts/validate-config-doc-example.ts"
   },
   "keywords": [
     "cli",

--- a/scripts/validate-config-doc-example.ts
+++ b/scripts/validate-config-doc-example.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env npx tsx
+/**
+ * validate-config-doc-example.ts
+ *
+ * Reads docs/config-format.md, extracts the first fenced JSON code block
+ * in the annotated example section, strips `//` inline comments, parses
+ * the result, and validates it against TildeConfigSchema from src/config/schema.ts.
+ *
+ * Usage: npx tsx scripts/validate-config-doc-example.ts
+ * Exit 0: valid  |  Exit 1: invalid or error
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TildeConfigSchema } from '../src/config/schema.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const docPath = resolve(__dirname, '../docs/config-format.md');
+
+let raw: string;
+try {
+  raw = readFileSync(docPath, 'utf8');
+} catch (err) {
+  console.error(`❌ Could not read docs/config-format.md: ${(err as Error).message}`);
+  process.exit(1);
+}
+
+// Extract the first fenced JSON block (```json ... ```)
+const fenceMatch = raw.match(/```json\n([\s\S]*?)```/);
+if (!fenceMatch) {
+  console.error('❌ No fenced JSON code block found in docs/config-format.md');
+  process.exit(1);
+}
+
+const blockWithComments = fenceMatch[1];
+
+// Strip `//` inline comments (only outside strings — handles URLs like https:// and op://)
+function stripJsonComments(text: string): string {
+  let result = '';
+  let i = 0;
+  let inString = false;
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    if (inString) {
+      if (ch === '\\') {
+        // Escaped character — keep both chars and skip ahead
+        result += ch + (text[i + 1] ?? '');
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      result += ch;
+      i++;
+    } else {
+      if (ch === '"') {
+        inString = true;
+        result += ch;
+        i++;
+      } else if (ch === '/' && text[i + 1] === '/') {
+        // Line comment — skip to end of line
+        while (i < text.length && text[i] !== '\n') {
+          i++;
+        }
+      } else {
+        result += ch;
+        i++;
+      }
+    }
+  }
+
+  return result;
+}
+
+const stripped = stripJsonComments(blockWithComments);
+
+let parsed: unknown;
+try {
+  parsed = JSON.parse(stripped);
+} catch (err) {
+  console.error(`❌ JSON parse failed after stripping comments: ${(err as Error).message}`);
+  console.error('Stripped content:\n', stripped);
+  process.exit(1);
+}
+
+const result = TildeConfigSchema.safeParse(parsed);
+if (result.success) {
+  console.log('✅ Config doc example is valid');
+  process.exit(0);
+} else {
+  console.error('❌ Config doc example failed Zod validation:');
+  for (const issue of result.error.issues) {
+    console.error(`  - [${issue.path.join('.')}] ${issue.message}`);
+  }
+  process.exit(1);
+}

--- a/specs/005-ui-branding-consolidation/spec.md
+++ b/specs/005-ui-branding-consolidation/spec.md
@@ -90,7 +90,7 @@ A contributor or new user visits the GitHub repository. They find a README that 
 - **FR-003**: Duplicate component key warnings MUST be eliminated from the CLI render output.
 - **FR-004**: All internal navigation links on the docs site MUST resolve to correct paths relative to the `/tilde/` base path.
 - **FR-005**: A standard Thingstead logo MUST be created and delivered as an SVG source file plus PNG exports, committed to `docs/design/` in the repository. A `design-tokens.md` file in the same directory MUST document the approved color palette and typeface. Design tooling (e.g., Storybook) is out of scope for this iteration but the tokens foundation enables future migration.
-- **FR-006**: Brand colors and typeface MUST be defined and applied consistently across: README, install page, docs site, and CLI splash screen.
+- **FR-006**: Brand colors and typeface MUST be defined and applied consistently across: the install page, docs site, and CLI splash screen. GitHub Markdown surfaces (README) are excluded — custom CSS cannot be applied to GitHub-rendered Markdown.
 - **FR-007**: A favicon derived from the Thingstead logo MUST be present on all web surfaces (install page, docs site).
 - **FR-008**: The README MUST be consolidated to contain: a tagline, the one-liner install command, a short list of feature highlights, and a prominent link to the full docs site. Content beyond this scope MUST be removed from the README and confirmed to exist in the docs site instead.
 - **FR-009**: All markdown documentation files MUST be located within the `docs/` folder, with the exception of standard top-level repo files (README.md, CONTRIBUTING.md, CHANGELOG.md, LICENSE).

--- a/specs/005-ui-branding-consolidation/tasks.md
+++ b/specs/005-ui-branding-consolidation/tasks.md
@@ -81,6 +81,8 @@
 - [X] T0020 [US3] Add Thingstead logo to `site/tilde/index.html` — add parent brand attribution (e.g., "by Thingstead" with logo) in page footer using `docs/design/thingstead-logo.svg` referenced inline or as `<img src>` with correct relative path
 - [X] T0021 [US3] Configure Starlight favicon in `site/docs/astro.config.mjs` — add `favicon: { href: '/favicon.svg', type: 'image/svg+xml' }` to the Starlight integration config so the favicon from T017 is used on the docs site
 
+  **Depends on**: T0011 — both T0021 and T0011 modify `site/docs/astro.config.mjs`; run T0011 to completion before starting T0021 to avoid merge conflicts
+
 **Checkpoint**: `site/tilde/index.html` shows favicon in browser tab. `site/docs/` (built) shows favicon. `docs/design/` contains `thingstead-logo.svg`, `thingstead-logo.png`, `design-tokens.md`.
 
 ---
@@ -95,6 +97,8 @@
 - [X] T0023 [P] [US4] Update schema URL in `docs/config-format.md` — replace `tilde.sh` URL with `thingstead.io/tilde` URL (pre-migration cleanup before T024)
 - [X] T0024 [US4] Migrate `docs/config-format.md` to `site/docs/src/content/docs/config-format.md` — copy file with frontmatter (`title: Configuration Format`, `description: ...`) compatible with Starlight content collection format
 - [X] T0025 [US4] Add `config-format` page to Starlight sidebar in `site/docs/astro.config.mjs` — insert `{ label: 'Configuration Format', slug: 'config-format' }` in appropriate sidebar position
+
+  **Depends on**: T0011 — both T0025 and T0011 modify `site/docs/astro.config.mjs`; run T0011 to completion before starting T0025 to avoid merge conflicts
 - [X] T0026 [US4] Delete `docs/config-format.md` from repository root `docs/` — file has been migrated to `site/docs/src/content/docs/config-format.md` in T024
 - [X] T0027 [US4] Consolidate `README.md` — trim to: (1) Thingstead/tilde tagline, (2) one-liner install command, (3) 3–5 feature highlights, (4) "Full documentation →" link to `https://thingstead.io/tilde/docs/`; verify any content removed already exists in the docs site
 - [X] T0028 [US4] Update `CONTRIBUTING.md` project/file structure section — replace any outdated directory tree with current actual structure (reflecting `site/`, `docs/design/`, `src/`, `specs/`, `tests/`, `scripts/`, `terraform/`)

--- a/specs/006-docs-polish-spec-hygiene/checklists/requirements.md
+++ b/specs/006-docs-polish-spec-hygiene/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Specification Quality Checklist: Documentation Polish and Spec Hygiene
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.plan`.
+
+### Validation Pass Summary
+
+**Pass 1** — Initial review:
+
+- **Content Quality**: All sections complete. No tech-stack references. Written in plain language accessible to non-technical readers. ✅
+- **FR-001–FR-005**: All relate to `docs/config-format.md` restoration and completeness. Each is independently testable (e.g., "file exists at path", "every field is documented"). ✅
+- **FR-006–FR-008**: Version display requirements. FR-006 says "read dynamically from the project's own package manifest" — no mention of specific tooling. FR-008 adds graceful fallback. ✅
+- **FR-009–FR-010**: Logo and README branding. Observable outcomes (file exists, centred image in README). ✅
+- **FR-011**: Docs migration — testable by directory listing. ✅
+- **FR-012–FR-013**: Spec 005 corrections — directly verifiable by reading the target files. ✅
+- **Success Criteria**: SC-001 uses a user task test; SC-002 uses 100% consistency metric; SC-003 uses directory listing count; SC-004 uses browser verification; SC-005 uses file existence + visual check; SC-006–SC-007 use content reading; SC-008 uses field-by-field comparison. All measurable, none mention specific technologies. ✅
+- **Edge Cases**: Four edge cases covering partial existing content, duplicate content, theme rendering, and runtime fallback. ✅
+- **Assumptions**: Seven clear assumptions covering schema version scope, existing brand assets, README hosting, target audience definition, splash change scope, spec 005 editorial scope, and loose file migration strategy. ✅
+
+**Result**: All checklist items pass on first validation pass. No revisions required.

--- a/specs/006-docs-polish-spec-hygiene/contracts/config-format-doc.md
+++ b/specs/006-docs-polish-spec-hygiene/contracts/config-format-doc.md
@@ -1,0 +1,112 @@
+# Contract: Config Format Document
+
+**Spec**: 006-docs-polish-spec-hygiene  
+**FR**: FR-001, FR-002, FR-003, FR-004, FR-005  
+**Type**: Documentation contract (output file specification)
+
+---
+
+## Contract
+
+`docs/config-format.md` is the authoritative standalone reference for `tilde.config.json`. It MUST exist at exactly this repo path (not only within the Astro docs site source tree).
+
+---
+
+## Completeness requirement
+
+The document MUST cover 100% of fields in `src/config/schema.ts` (`TildeConfigSchema`). Verified by comparing documented fields against Zod schema exports. As of spec 006:
+
+### Required fields checklist
+
+**Top-level** (TildeConfigSchema):
+- [x] `$schema` — optional string (JSON Schema URL for editor tooling)
+- [x] `version` — literal `"1"`, required
+- [x] `schemaVersion` — integer ≥ 1, default `1`, required
+- [x] `os` — literal `"macos"`, required
+- [x] `shell` — enum `"zsh" | "bash" | "fish"`, required
+- [x] `packageManager` — literal `"homebrew"`, required
+- [x] `versionManagers` — array of VersionManager, required
+- [x] `languages` — array of Language, required
+- [x] `workspaceRoot` — string, required
+- [x] `dotfilesRepo` — string (absolute or `~/`-prefixed), required
+- [x] `contexts` — array of DeveloperContext (min 1), required
+- [x] `tools` — array of strings, optional (default `[]`)
+- [x] `configurations` — ConfigurationDomains object, required
+- [x] `accounts` — array of Account, optional (default `[]`)
+- [x] `secretsBackend` — enum `"1password" | "keychain" | "env-only"`, required
+
+**VersionManager object**:
+- [x] `name` — enum `"vfox" | "nvm" | "pyenv" | "sdkman"`
+
+**Language object**:
+- [x] `name` — string
+- [x] `version` — string
+- [x] `manager` — string (must reference a `versionManagers[].name`)
+
+**DeveloperContext object**:
+- [x] `label` — string (must be unique across contexts)
+- [x] `path` — string
+- [x] `git.name` — string
+- [x] `git.email` — valid email string
+- [x] `github.username` — optional string
+- [x] `authMethod` — enum `"gh-cli" | "https" | "ssh"` — **wizard phrasing required**
+- [x] `envVars` — optional array of EnvVarReference — **wizard phrasing required**
+- [x] `vscodeProfile` — optional string
+- [x] `isDefault` — optional boolean
+
+**EnvVarReference object**:
+- [x] `key` — string
+- [x] `value` — string (secrets backend reference; blocked patterns: `ghp_`, `sk-`, `AKIA`, `xox[bp]-`)
+
+**ConfigurationDomains object**:
+- [x] `git` — boolean
+- [x] `vscode` — boolean
+- [x] `aliases` — boolean
+- [x] `osDefaults` — boolean
+- [x] `direnv` — boolean
+
+**Account object**:
+- [x] `service` — string
+- [x] `identifier` — string
+- [x] `secretRef` — optional string
+
+---
+
+## Annotated example requirement (FR-003)
+
+The document MUST include a complete annotated example covering:
+- All required fields
+- Representative optional fields (`$schema`, `tools`, `accounts`, `vscodeProfile`, `isDefault`)
+- Multiple contexts (to demonstrate context array)
+- Inline comments on every field (using `//` in JSON with a note that real JSON doesn't support comments, or using a side-by-side callout table)
+- `schemaVersion: 1` explicitly set
+
+---
+
+## Schema versioning section requirement (FR-004)
+
+The schema versioning section MUST contain all of:
+
+1. **What `schemaVersion` means** — version number of the config file format; tilde reads this at startup to decide whether migration is needed
+2. **v1: inaugural schema** — explicit statement that v1 is the first version; no prior versions exist; any config already at v1 requires no migration
+3. **Migration runner behaviour** — when a config with `schemaVersion < current` is loaded: tilde detects the version, applies all applicable migration steps in order, writes back atomically, and notifies the user. Migration is always additive and non-destructive (adds defaults, renames deprecated fields; never removes user data or alters user-set values). If migration fails: warn the user, preserve the original file unmodified, offer wizard re-run.
+4. **Forward version handling** — if a config's `schemaVersion` is higher than the installed tilde supports: warn the user and open in read-only mode; prompt to upgrade tilde
+5. **Future migration template skeleton** — a clearly labelled example block showing the pattern future v2 migration entries will follow
+
+---
+
+## Audience and language requirements (FR-005)
+
+- No references to TypeScript, Zod, compiler behaviour, or internal types
+- No jargon: "enum" → "one of the following values"; "optional" → "you don't have to set this"; "array" → "list"
+- Technically-named fields use wizard-equivalent descriptions (see `data-model.md` Wizard-Equivalent Phrasing Map)
+- All valid value sets are written as plain lists, not type union syntax
+
+---
+
+## File format requirements
+
+- Plain Markdown (no Astro frontmatter, no MDX, no shortcodes)
+- Renders correctly on GitHub.com (table syntax, fenced code blocks)
+- No relative links that would break outside the docs site context
+- All internal links are anchor references within the same document

--- a/specs/006-docs-polish-spec-hygiene/contracts/logo-variation.md
+++ b/specs/006-docs-polish-spec-hygiene/contracts/logo-variation.md
@@ -1,0 +1,84 @@
+# Contract: Tilde Logo Variation SVG
+
+**Spec**: 006-docs-polish-spec-hygiene  
+**FR**: FR-009, FR-010  
+**Type**: Design asset contract
+
+---
+
+## Contract
+
+`docs/design/tilde-logo-variation.svg` is the tilde product logomark. It MUST be created as a brand-consistent SVG that is visually distinct from `docs/design/thingstead-logo.svg` through incorporation of the `~` tilde character.
+
+---
+
+## Asset specification
+
+| Property | Value | Source |
+|---|---|---|
+| Output path | `docs/design/tilde-logo-variation.svg` | FR-009 |
+| `viewBox` | `0 0 120 60` | Aspect ratio for 2:1 horizontal logomark |
+| Background | `#030712` filled `<rect>` with `rx="8"` | design-tokens.md `--color-bg` |
+| Primary colour | `#4ade80` | design-tokens.md `--color-brand` |
+| Wave bezier path | `M4 22 C8 10, 14 10, 16 22 C18 34, 24 34, 28 22` (scaled) | design-tokens.md Wave mark |
+| Wave stroke | `stroke="#4ade80" stroke-width="4" stroke-linecap="round" fill="none"` | design-tokens.md |
+| Tilde character | `~` rendered as SVG `<text>` in brand green | FR-009 distinguishing element |
+| Typeface (text) | `ui-monospace, 'Cascadia Code', 'Fira Code', monospace` | design-tokens.md Typeface Stack |
+| No fixed width/height | Scales to container via `viewBox` only | GitHub README responsive |
+
+---
+
+## Rendering requirements
+
+| Requirement | Verification |
+|---|---|
+| Renders without errors as a standalone SVG | Open in browser directly |
+| Legible at `width="160"` (README context) | View at 160px width |
+| Dark background visible against GitHub light theme | Screenshot on GitHub.com |
+| No external dependencies (fonts, URLs, images) | Inspect SVG source |
+| `<title>` element for accessibility | `<title>tilde</title>` present |
+| Passes SVG well-formedness | No unclosed tags, valid namespace |
+
+---
+
+## README integration contract (FR-010)
+
+The README.md `<div align="center">` block MUST be updated to include the logo `<img>`:
+
+```html
+<div align="center">
+  <img src="docs/design/tilde-logo-variation.svg" alt="tilde" width="160"/>
+  <br/><br/>
+  <img src="docs/banner.svg" alt="tilde — developer environment bootstrap" width="560"/>
+  ...badges...
+</div>
+```
+
+### Constraints
+- `src` path: relative path from repo root (`docs/design/tilde-logo-variation.svg`) — works on GitHub.com
+- `alt` text: `"tilde"` (product name only, concise)
+- `width`: `"160"` — appropriate for a product logomark in a README header
+- `banner.svg` MUST NOT be replaced or removed
+- The logo `<img>` MUST appear above the banner `<img>`
+- Both `<img>` elements remain inside the same `<div align="center">` wrapper
+
+---
+
+## Visual consistency requirements
+
+| Check | Requirement |
+|---|---|
+| Colour palette | Only `#4ade80`, `#030712`, and optionally muted `#9ca3af` — no other colours |
+| No serif/proportional fonts | Monospace typeface stack only |
+| Brand accent colour `#4ade80` passes WCAG AA | Against `#030712` background — contrast ratio ~8:1 ✓ |
+| Wave path unchanged | Uses exact bezier from design-tokens.md Wave mark section |
+| Distinguishing element present | `~` tilde character visually present in the mark |
+
+---
+
+## Non-goals
+
+- This asset does NOT replace `docs/design/thingstead-logo.svg`
+- This asset does NOT replace `docs/banner.svg`
+- This asset is NOT used as a favicon (existing favicons remain in `site/*/public/`)
+- No animation required (static SVG only)

--- a/specs/006-docs-polish-spec-hygiene/contracts/version-reading.md
+++ b/specs/006-docs-polish-spec-hygiene/contracts/version-reading.md
@@ -1,0 +1,86 @@
+# Contract: Runtime Version Reading
+
+**Spec**: 006-docs-polish-spec-hygiene  
+**FR**: FR-006, FR-007, FR-008  
+**Type**: Internal module contract
+
+---
+
+## Contract
+
+The `readPackageVersion()` function is an exported helper in `src/index.tsx` (exported for testability; not intended as a public API) that reads the running tilde version from `package.json` at startup.
+
+### Signature
+
+```typescript
+export function readPackageVersion(): string
+```
+
+### Guarantees
+
+| Guarantee | Detail |
+|---|---|
+| **Return type** | Always `string` — never throws |
+| **Normal return** | Semver string from `package.json` `"version"` field (e.g., `"1.2.0"`) |
+| **Fallback return** | `"unknown"` on any error (file not found, JSON parse failure, missing field) |
+| **ESM-safe** | Resolves path via `import.meta.url` — no `__dirname`, no `createRequire` |
+| **Mechanism** | `readFileSync` + `JSON.parse` only — no import assertions, no `process.env.npm_package_version` |
+| **Sync** | Synchronous — called once at module load time before `parseCliArgs()` |
+
+### Path resolution
+
+```
+import.meta.url → file:///path/to/dist/index.js
+fileURLToPath(import.meta.url) → /path/to/dist/index.js
+dirname(...) → /path/to/dist
+resolve(dirname, '../package.json') → /path/to/package.json  ✓
+```
+
+### Error contract
+
+All errors are caught internally. The caller receives `'unknown'` for any failure:
+
+```typescript
+function readPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const pkgPath = resolve(__dirname, '../package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+```
+
+### Downstream contract
+
+The value returned by `readPackageVersion()` replaces the `const VERSION = '0.1.0'` constant on line 15 of `src/index.tsx`. It flows as:
+
+```
+VERSION → App.props.version → captureEnvironment(version) → EnvironmentSnapshot.tildeVersion
+       → Splash display: v{tildeVersion}
+       → CompactHeader display: v{tildeVersion}
+       → --version flag output: tilde v{VERSION}
+```
+
+All three display points MUST show the same value. No manual synchronisation step is permitted.
+
+### Excluded mechanisms (per FR-006)
+
+- ❌ `createRequire(import.meta.url)('./package.json').version`
+- ❌ `import pkg from './package.json' assert { type: 'json' }`
+- ❌ `process.env.npm_package_version`
+- ❌ Hardcoded string constants
+- ❌ Build-time substitution via `esbuild.define` or similar
+
+---
+
+## Testing contract
+
+**Existing test coverage**: `tests/unit/utils/environment.test.ts` tests `captureEnvironment('1.2.3')` and verifies `snapshot.tildeVersion === '1.2.3'`. This is sufficient for the environment chain.
+
+**New test required**: Unit test for `readPackageVersion()` itself:
+- Normal case: returns version string matching `package.json`
+- Fallback case: returns `'unknown'` when path resolves to a nonexistent file (mock `readFileSync` to throw)

--- a/specs/006-docs-polish-spec-hygiene/data-model.md
+++ b/specs/006-docs-polish-spec-hygiene/data-model.md
@@ -1,0 +1,200 @@
+# Data Model: Documentation Polish and Spec Hygiene
+
+**Branch**: `006-docs-polish-spec-hygiene`  
+**Phase**: 1 — Design  
+**Derived from**: `spec.md` + `research.md`
+
+---
+
+## Overview
+
+This spec is a documentation and hygiene feature. There are no new runtime data structures. The "entities" are:
+
+1. **Config Format Document** — the `docs/config-format.md` file and its structural schema
+2. **tilde.config.json schema** — existing Zod-defined schema (reference only; no changes)
+3. **Tilde Logo Variation** — the `docs/design/tilde-logo-variation.svg` asset
+4. **Runtime Version Value** — the string read from `package.json` at startup
+5. **Spec 005 Corrections** — editorial changes to spec artifacts (no runtime entities)
+
+---
+
+## Entity 1: Config Format Document (`docs/config-format.md`)
+
+### Purpose
+Standalone Markdown reference at the mandated repo path `docs/config-format.md`. Audience: non-technical users authoring `tilde.config.json` without the wizard.
+
+### Document Structure
+
+```
+docs/config-format.md
+├── Header / intro (1 paragraph)
+├── Quick-start annotated example (complete JSON with inline comments)
+├── Top-level fields table
+├── Sub-schemas (one section per object type)
+│   ├── VersionManager
+│   ├── Language
+│   ├── DeveloperContext
+│   │   └── EnvVarReference (nested)
+│   ├── ConfigurationDomains
+│   └── Account
+├── Secrets backends (reference table)
+├── File locations (where tilde writes dotfiles)
+├── Environment variables (CLI env var reference)
+└── Schema versioning and migration
+    ├── What schemaVersion means
+    ├── v1: Inaugural schema (no migration required)
+    ├── How the migration runner works
+    └── Future migration template skeleton
+```
+
+### Wizard-Equivalent Phrasing Map (FR-005)
+
+| Field (technical name) | Wizard question / purpose-driven description |
+|---|---|
+| `authMethod` | "How will you authenticate to GitHub in this context?" — `gh-cli`: use the GitHub CLI; `https`: HTTPS with a credential helper; `ssh`: SSH key pair |
+| `envVars` | "Environment variables to load when you're working in this context (use your secrets backend references — not raw tokens)" |
+| `secretsBackend` | "Where should tilde store and retrieve your secrets?" — `1password`: 1Password CLI (`op://` references); `keychain`: macOS Keychain; `env-only`: a local non-tracked file |
+| `vscodeProfile` | "Which VS Code profile should be active in this context?" |
+| `isDefault` | "Is this the context tilde should use when you're not inside any named workspace path?" |
+| `configurations.direnv` | "Should tilde manage `.envrc` files for automatic context switching?" |
+| `configurations.osDefaults` | "Should tilde apply macOS system preferences defined in your dotfiles?" |
+
+### Validation Rules (from Zod schema — document in plain English)
+
+| Rule | Plain-English description |
+|---|---|
+| `contexts` array minimum length: 1 | At least one developer context is required |
+| `contexts[].label` uniqueness | Each context must have a different name |
+| `languages[].manager` reference | Every language manager must match one of the listed version managers |
+| `envVars[].value` pattern block | Values starting with `ghp_`, `sk-`, `AKIA`, or `xox[bp]-` are rejected — use a secrets backend reference |
+| `dotfilesRepo` path format | Must be an absolute path or start with `~/` |
+| `git.email` format | Must be a valid email address |
+
+---
+
+## Entity 2: tilde.config.json Schema (Reference — No Changes)
+
+The canonical schema is defined in `src/config/schema.ts`. This spec does not modify the schema. The schema is documented in `docs/config-format.md` (Entity 1).
+
+**Schema version**: `1` (inaugural — no prior versions exist)  
+**Zod type export**: `TildeConfig` (used by `loadConfig()` in `src/config/reader.ts`)
+
+### Schema Version Lifecycle
+
+```
+schemaVersion = 1 (inaugural)
+  │
+  │  On load: tilde compares file schemaVersion to current supported version
+  │  If same version → validate directly
+  │  If older version → run migration steps additively → write back → notify user
+  │  If newer version → warn user → open config read-only → prompt to upgrade tilde
+  │
+  └─► tilde v2 (future): will introduce schemaVersion = 2
+       - All migrations additive and non-destructive
+       - New fields added with defaults; deprecated fields renamed, not removed
+       - Migration failure: warn user, preserve original, offer wizard re-run
+```
+
+---
+
+## Entity 3: Tilde Logo Variation (`docs/design/tilde-logo-variation.svg`)
+
+### Purpose
+A tilde-specific product logomark derived from the Thingstead brand. Used in the README header (FR-010). Distinguishing element: the `~` tilde character incorporated into the mark.
+
+### SVG Specification
+
+| Attribute | Value | Source |
+|---|---|---|
+| `viewBox` | `0 0 120 60` | Sized for README `width="160"` rendering |
+| Background fill | `#030712` (brand bg) | `docs/design/design-tokens.md` → `--color-bg` |
+| Primary colour | `#4ade80` (brand green) | `docs/design/design-tokens.md` → `--color-brand` |
+| Wave path stroke | `#4ade80`, `stroke-width="4"`, `stroke-linecap="round"`, `fill="none"` | design-tokens.md Wave mark spec |
+| Wave bezier | `M4 22 C8 10, 14 10, 16 22 C18 34, 24 34, 28 22` (scaled to viewBox) | design-tokens.md Wave mark spec |
+| Tilde text glyph | SVG `<text>` element, monospace font, `#4ade80` fill | Distinguishing product element |
+| No fixed width/height | Scales to container | GitHub README responsive |
+
+### Structural elements
+
+```svg
+<svg viewBox="0 0 120 60" xmlns="http://www.w3.org/2000/svg">
+  <!-- Dark background (required for dark-on-dark terminal aesthetic) -->
+  <rect width="120" height="60" fill="#030712" rx="8"/>
+  <!-- Wave mark (from design tokens) -->
+  <path ... stroke="#4ade80" .../> 
+  <!-- Tilde character logomark -->
+  <text ... fill="#4ade80">~</text>
+  <!-- Optional: "tilde" wordmark in brand green -->
+  <text ... fill="#4ade80" opacity="0.7">tilde</text>
+</svg>
+```
+
+### State transitions
+N/A — static asset
+
+---
+
+## Entity 4: Runtime Version Value
+
+### Purpose
+The tilde version string displayed on the splash screen and `--version` output. Must be read dynamically from `package.json` at startup (not hardcoded).
+
+### Data flow
+
+```
+package.json { "version": "1.2.0" }
+        │
+        │ readFileSync + JSON.parse
+        │ resolved via import.meta.url → ../package.json
+        ▼
+readPackageVersion(): string  (in src/index.tsx)
+        │
+        │ const VERSION = readPackageVersion()  (replaces hardcoded '0.1.0')
+        ▼
+App props: { version: VERSION }
+        │
+        ▼
+captureEnvironment(version) → EnvironmentSnapshot.tildeVersion
+        │
+        ▼
+Splash: v{environment.tildeVersion}
+CompactHeader: v{tildeVersion}
+--version flag: `tilde v${VERSION}`
+```
+
+### Fallback state
+
+| Condition | Behaviour |
+|---|---|
+| `package.json` not found | Returns `'unknown'` |
+| JSON parse error | Returns `'unknown'` |
+| `version` field missing | Returns `'unknown'` |
+| Normal operation | Returns semver string, e.g. `'1.2.0'` |
+
+---
+
+## Entity 5: Spec 005 Corrections (Editorial — No Runtime Entities)
+
+### spec.md FR-006 change
+
+| | Before | After |
+|---|---|---|
+| Surfaces listed | README, install page, docs site, CLI splash screen | install page, docs site, CLI splash screen |
+| Rationale for removal | GitHub Markdown cannot receive custom CSS/colours | Enforceable surfaces only |
+
+### tasks.md dependency additions
+
+| Task | New dependency | Rationale |
+|---|---|---|
+| T0021 | T0011 | Both modify `site/docs/astro.config.mjs`; must run sequentially |
+| T0025 | T0011 | Both modify `site/docs/astro.config.mjs`; must run sequentially |
+
+---
+
+## No New Persistent State
+
+This feature introduces no new database tables, no new config fields, no new API endpoints, and no new plugin contracts. All changes are to:
+- Static documentation files
+- A single SVG asset
+- A single line of source code (`const VERSION` declaration)
+- Spec artifact corrections (editorial only)

--- a/specs/006-docs-polish-spec-hygiene/plan.md
+++ b/specs/006-docs-polish-spec-hygiene/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Documentation Polish and Spec Hygiene
+
+**Branch**: `006-docs-polish-spec-hygiene` | **Date**: 2026-03-31 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/006-docs-polish-spec-hygiene/spec.md`
+
+## Summary
+
+This feature resolves two P1 constitution violations (missing `docs/config-format.md`, hardcoded CLI version constant) and delivers three follow-on improvements: a tilde product logo variation SVG, a README logo header, and spec 005 editorial corrections. No new runtime schema, no API changes, no new plugin contracts. The only source code change is replacing `const VERSION = '0.1.0'` in `src/index.tsx` with a runtime read of `package.json` via `readFileSync + JSON.parse` anchored to `import.meta.url`.
+
+**Deliverables**:
+1. `docs/config-format.md` — standalone plain-English schema reference (based on existing Starlight draft at `site/docs/src/content/docs/config-format.md`, expanded with wizard phrasing and complete migration section)
+2. `src/index.tsx` — single-line fix: `const VERSION = readPackageVersion()` replacing `'0.1.0'`
+3. `docs/design/tilde-logo-variation.svg` — brand-consistent product logomark with `~` character
+4. `README.md` — logo `<img>` inserted in existing `<div align="center">` header
+5. `specs/005-ui-branding-consolidation/spec.md` — FR-006 narrowed (remove README surface)
+6. `specs/005-ui-branding-consolidation/tasks.md` — T0021 and T0025 declare T0011 dependency
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.4, Node.js 20 LTS, ESM (`"type": "module"`)  
+**Primary Dependencies**: Ink (React terminal UI), Zod (config schema validation), `node:fs`, `node:url`, `node:path`  
+**Storage**: File system only — `docs/`, `docs/design/`, `src/`, `specs/`  
+**Testing**: Vitest (`npm test`) — existing unit tests cover `captureEnvironment`; one new unit test for `readPackageVersion()` fallback  
+**Target Platform**: macOS (runtime); GitHub.com (SVG and Markdown rendering)  
+**Project Type**: CLI tool  
+**Performance Goals**: N/A — startup-time file read is synchronous and sub-millisecond  
+**Constraints**: ESM-safe version reading only (no `createRequire`, no import assertions, no `process.env.npm_package_version`); SVG must render on GitHub in both light and dark themes  
+**Scale/Scope**: 6 files changed or created; ~1 source line changed; ~2 new documentation files; 1 new SVG asset; 2 spec artifact edits
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-design check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Configuration-First | ⚠️ VIOLATION (being fixed) | `docs/config-format.md` absent from repo root — users cannot author config-first without this file. **This spec fixes the violation.** |
+| II. Bootstrap-Ready | ✅ pass | No change to bootstrap path |
+| III. Context-Aware Environments | ✅ pass | No change to context switching |
+| IV. Interactive & Ink-First UX | ⚠️ VIOLATION (being fixed) | Splash displays `v0.1.0` (hardcoded) instead of dynamic runtime version. **This spec fixes the violation.** |
+| V. Idempotent Operations | ✅ pass | No new mutations introduced |
+| VI. Secrets-Free Repository | ✅ pass | No secrets; SVG and Markdown contain no credentials |
+| VII. macOS First | ✅ pass | All changes target macOS or are platform-agnostic docs |
+| VIII. Extensibility & Plugin Architecture | ✅ pass | No plugin changes |
+
+**Constitution requirement: `docs/config-format.md` must exist** (`Technology Constraints → Entry Modes` section):
+> "The config file format MUST be documented in `docs/config-format.md` within the repo"
+
+→ This spec creates the file. ✅
+
+**Constitution requirement: FR-009 (all markdown docs in `docs/`):**
+→ Root audit (RES-005) confirms root is already compliant. ✅
+
+### Post-design re-check
+
+All Phase 1 design decisions are consistent with constitution requirements:
+- Version reading via `readFileSync + JSON.parse` satisfies Principle IV dynamic display requirement
+- `docs/config-format.md` satisfies Principle I + Entry Modes mandate
+- SVG and README changes are purely additive; no existing behaviour altered
+- Spec 005 editorial corrections are narrowing-only; no new constitution conflicts introduced
+
+**GATE PASSED** — no unjustified violations. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-docs-polish-spec-hygiene/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — all NEEDS CLARIFICATION resolved
+├── data-model.md        # Phase 1 output — entities and data flows
+├── quickstart.md        # Phase 1 output — step-by-step implementer guide
+├── contracts/
+│   ├── version-reading.md    # readPackageVersion() function contract
+│   ├── config-format-doc.md  # docs/config-format.md completeness contract
+│   └── logo-variation.md     # SVG asset and README integration contract
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── index.tsx            # Line 15: const VERSION = readPackageVersion() [1 line change]
+
+docs/
+├── config-format.md     # NEW: standalone schema reference (FR-001–FR-005)
+└── design/
+    ├── design-tokens.md          # unchanged (authoritative source)
+    ├── thingstead-logo.svg       # unchanged
+    └── tilde-logo-variation.svg  # NEW: product logomark (FR-009)
+
+README.md                # Updated: logo <img> added to <div align="center"> header (FR-010)
+
+specs/005-ui-branding-consolidation/
+├── spec.md              # FR-006 narrowed: remove README surface (FR-012)
+└── tasks.md             # T0021 + T0025 declare T0011 dependency (FR-013)
+
+tests/unit/
+└── (new test for readPackageVersion() fallback — optional, recommended)
+```
+
+**Structure Decision**: Single-project layout. All changes are in `src/`, `docs/`, `README.md`, and spec artifacts. No new directories except the already-existing `docs/design/` target.
+
+## Complexity Tracking
+
+> No constitution violations to justify — this spec resolves existing violations, it does not introduce them.

--- a/specs/006-docs-polish-spec-hygiene/quickstart.md
+++ b/specs/006-docs-polish-spec-hygiene/quickstart.md
@@ -1,0 +1,199 @@
+# Quickstart: Implementing Spec 006
+
+**Branch**: `006-docs-polish-spec-hygiene`  
+**For**: Implementer picking up this work from scratch
+
+---
+
+## What this spec delivers
+
+5 user stories, all documentation / hygiene — no new APIs, no schema changes, no new tests beyond a unit test for version reading:
+
+| Story | Priority | Work type | Files changed |
+|---|---|---|---|
+| US1: Config-format docs | P1 | Create doc | `docs/config-format.md` (new) |
+| US2: Dynamic CLI version | P1 | Source fix | `src/index.tsx` (1 line) |
+| US3: README logo + SVG | P2 | Create asset + update doc | `docs/design/tilde-logo-variation.svg` (new), `README.md` |
+| US4: Markdown location audit | P2 | Verification only | None (already compliant) |
+| US5: Spec 005 hygiene | P3 | Edit spec artifacts | `specs/005-ui-branding-consolidation/spec.md`, `tasks.md` |
+
+---
+
+## Prerequisites
+
+```bash
+git checkout 006-docs-polish-spec-hygiene
+cd /Users/jeff.williams/Developer/personal/tilde
+```
+
+Verify you can build and run tests:
+
+```bash
+npm run build
+npm test
+```
+
+---
+
+## Step 1: Fix dynamic version in CLI (US2 — P1)
+
+**File**: `src/index.tsx`
+
+Replace line 15:
+```typescript
+// BEFORE
+const VERSION = '0.1.0';
+
+// AFTER
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+function readPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const pkgPath = resolve(__dirname, '../package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+const VERSION = readPackageVersion();
+```
+
+> Note: `fileURLToPath` and `dirname`/`resolve` are likely already imported in the file (check existing `import` lines at the top — `resolve` is used on line ~16 via `node:path`). Add only what is missing.
+
+**Verify**:
+```bash
+npm run build
+node dist/index.js --version  # Should print: tilde v1.2.0
+```
+
+---
+
+## Step 2: Create `docs/config-format.md` (US1 — P1)
+
+**Source**: `site/docs/src/content/docs/config-format.md` (existing Starlight draft — accurate but incomplete)
+
+**Steps**:
+1. Copy the Starlight draft to `docs/config-format.md`
+2. Remove the Astro frontmatter block (`--- title: ... ---` at top)
+3. Add a Markdown H1 header: `# tilde Configuration Format`
+4. Expand the schema versioning section (bottom of file) per `contracts/config-format-doc.md` requirements:
+   - Add explicit statement that v1 is the inaugural schema
+   - Add migration runner behaviour detail
+   - Add forward-version warning behaviour
+   - Add future migration template skeleton
+5. Apply wizard-equivalent phrasing to `authMethod`, `envVars`, and `secretsBackend` per `data-model.md` Phrasing Map
+6. Verify the annotated example includes `schemaVersion: 1` and covers all required fields
+
+**Verify**:
+```bash
+# Check all schema fields are documented
+grep -c "authMethod\|envVars\|secretsBackend\|schemaVersion\|workspaceRoot\|dotfilesRepo\|contexts\|versionManagers" docs/config-format.md
+# Should find ≥ 8 matches
+```
+
+---
+
+## Step 3: Create tilde logo variation SVG (US3 — P2)
+
+**File**: `docs/design/tilde-logo-variation.svg`
+
+Create the SVG per `contracts/logo-variation.md`. Key attributes:
+- `viewBox="0 0 120 60"`, no fixed width/height
+- Dark background rect `fill="#030712" rx="8"`
+- Wave bezier path: `stroke="#4ade80" stroke-width="4" stroke-linecap="round" fill="none"`
+- The tilde character `~` as a `<text>` element in `#4ade80`
+- `<title>tilde</title>` for accessibility
+
+**Verify**:
+```bash
+# File exists and is valid XML
+xmllint --noout docs/design/tilde-logo-variation.svg && echo "Valid SVG"
+```
+
+---
+
+## Step 4: Update README.md header (US3 — P2)
+
+**File**: `README.md`
+
+In the `<div align="center">` block, insert the logo `<img>` above the banner:
+
+```html
+<div align="center">
+  <img src="docs/design/tilde-logo-variation.svg" alt="tilde" width="160"/>
+  <br/><br/>
+  <img src="docs/banner.svg" alt="tilde — developer environment bootstrap" width="560"/>
+  ...rest unchanged...
+</div>
+```
+
+**Verify**: Open README.md preview in VS Code or view on GitHub to confirm both images render.
+
+---
+
+## Step 5: Markdown location audit (US4 — P2)
+
+Run the audit to confirm the repo root is already compliant:
+
+```bash
+# Should return only README.md, CONTRIBUTING.md, CHANGELOG.md
+find /Users/jeff.williams/Developer/personal/tilde -maxdepth 1 -name "*.md" | sort
+```
+
+Expected output — exactly three files:
+```
+/Users/jeff.williams/Developer/personal/tilde/CHANGELOG.md
+/Users/jeff.williams/Developer/personal/tilde/CONTRIBUTING.md
+/Users/jeff.williams/Developer/personal/tilde/README.md
+```
+
+No migration needed. Record verification result as SC-003 pass.
+
+---
+
+## Step 6: Spec 005 hygiene corrections (US5 — P3)
+
+### 6a. Edit `specs/005-ui-branding-consolidation/spec.md`
+
+Find FR-006 (line 93):
+```
+- **FR-006**: Brand colors and typeface MUST be defined and applied consistently across: README, install page, docs site, and CLI splash screen.
+```
+
+Replace with:
+```
+- **FR-006**: Brand colors and typeface MUST be defined and applied consistently across: the install page, docs site, and CLI splash screen. GitHub Markdown surfaces (README) are excluded — custom CSS cannot be applied to GitHub-rendered Markdown.
+```
+
+### 6b. Edit `specs/005-ui-branding-consolidation/tasks.md`
+
+Find T0021 (line ~82) and add after its main description:
+```
+  - **Depends on**: T0011 — both T0021 and T0011 modify `site/docs/astro.config.mjs`; run T0011 to completion before starting T0021 to avoid merge conflicts.
+```
+
+Find T0025 (line ~97) and add after its main description:
+```
+  - **Depends on**: T0011 — both T0025 and T0011 modify `site/docs/astro.config.mjs`; run T0011 to completion before starting T0025 to avoid merge conflicts.
+```
+
+---
+
+## Acceptance checklist
+
+| SC | Check | How to verify |
+|---|---|---|
+| SC-001 | Config-format doc complete | Compare fields against `src/config/schema.ts` |
+| SC-002 | Splash version matches package.json | `node dist/index.js --version` → compare to `jq .version package.json` |
+| SC-003 | No extra root `.md` files | `find . -maxdepth 1 -name "*.md"` → 3 results |
+| SC-004 | Logo visible and centred in README | View README on GitHub |
+| SC-005 | SVG renders without errors | Open in browser; `xmllint --noout` passes |
+| SC-006 | Spec 005 FR-006 has no CSS/README ref | Read revised FR-006 |
+| SC-007 | T0021 and T0025 declare T0011 dependency | Read tasks.md entries |
+| SC-008 | 100% schema field coverage | Field-by-field compare vs Zod schema |

--- a/specs/006-docs-polish-spec-hygiene/research.md
+++ b/specs/006-docs-polish-spec-hygiene/research.md
@@ -1,0 +1,200 @@
+# Research: Documentation Polish and Spec Hygiene
+
+**Branch**: `006-docs-polish-spec-hygiene`  
+**Phase**: 0 — Pre-design research  
+**Date**: 2026-03-31
+
+---
+
+## RES-001: ESM-Safe Runtime Version Reading (FR-006, FR-007, FR-008)
+
+**Question**: What is the correct way to read `package.json` at runtime given `"type": "module"` in package.json and Node ≥ 20, without import assertions or `createRequire`?
+
+**Decision**: Use `readFileSync` + `JSON.parse` resolved via `import.meta.url`
+
+**Implementation pattern**:
+
+```typescript
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+function readPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const pkgPath = resolve(__dirname, '../package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+```
+
+**Path resolution**: `dist/index.js` → `../package.json` (one level up from `dist/`). The `tsconfig.json` emits to `outDir: "dist"`, so source files at `src/*.ts` become `dist/*.js`, and `package.json` at repo root is one `..` from `dist/`.
+
+**Rationale**:
+- `readFileSync` + `JSON.parse` is standard, dependency-free, Node ≥ 12 compatible
+- `import.meta.url` is the correct ESM anchor (not `__dirname`, not `process.cwd()`)
+- Works identically whether invoked as `npx`, `npm install -g`, or direct `node dist/index.js`
+- `createRequire` is an unnecessary complexity when `readFileSync` suffices
+- Import assertions (`import pkg from './package.json' assert { type: 'json' }`) are still non-stable in Node 20 and explicitly excluded by the spec
+- `process.env.npm_package_version` is not set when tilde is invoked via `npx` in some environments — explicitly excluded by the spec
+
+**Fallback**: Wrap in try/catch; return `'unknown'` on any error (file not found, JSON parse failure, unexpected install layout).
+
+**Integration point**: `src/index.tsx` line 15 (`const VERSION = '0.1.0'`) → replace with `readPackageVersion()` call. `version: VERSION` on line 287 feeds `App` props → `captureEnvironment(version)` (app.tsx line 76) → `EnvironmentSnapshot.tildeVersion` → `Splash` component. The entire chain is already correct; only the source value is wrong.
+
+**Alternatives considered**:
+- `createRequire(import.meta.url)('./package.json').version` — works but adds cognitive overhead and an unnecessary `module` module import
+- Baking version at build time via `esbuild` define / `tsc` const — would break the "update without source changes" scenario in SC-002
+- `process.env.npm_package_version` — unreliable outside npm script context
+
+---
+
+## RES-002: `docs/config-format.md` — Scope and Authoritative Source (FR-001–FR-005)
+
+**Question**: Is there existing content that can serve as a base, and what fields are missing?
+
+**Decision**: The file at `site/docs/src/content/docs/config-format.md` is a near-complete but Starlight-scoped draft. It must be adapted into a standalone `docs/config-format.md` at the repo root `docs/` folder (removing Astro frontmatter, adding missing wizard-phrasing, completing schema versioning section per FR-004).
+
+**Gap analysis against `src/config/schema.ts`**:
+
+| Schema field / sub-schema | In Starlight draft? | Gap |
+|---|---|---|
+| `$schema` | ✅ yes | — |
+| `version` (literal `"1"`) | ✅ yes | — |
+| `schemaVersion` | ✅ yes | FR-004 migration section needs inaugural v1 callout + template skeleton |
+| `os` | ✅ yes | — |
+| `shell` | ✅ yes | — |
+| `packageManager` | ✅ yes | — |
+| `versionManagers` | ✅ yes | — |
+| `languages` | ✅ yes | — |
+| `workspaceRoot` | ✅ yes | — |
+| `dotfilesRepo` | ✅ yes | — |
+| `contexts` | ✅ yes | — |
+| `contexts[].authMethod` | ✅ yes | FR-005: description must use wizard-equivalent phrasing ("How will you authenticate to GitHub for this context?") not raw enum label |
+| `contexts[].envVars` | ✅ yes | FR-005: describe as "Environment variables for this context (use secrets backend references, not raw values)" |
+| `contexts[].vscodeProfile` | ✅ yes | — |
+| `contexts[].isDefault` | ✅ yes | — |
+| `tools` | ✅ yes | — |
+| `configurations` | ✅ yes | — |
+| `accounts` | ✅ yes | — |
+| `secretsBackend` | ✅ yes | FR-005: describe as "Where should tilde store and retrieve your secrets?" not internal enum |
+| `schemaVersion` migration section | ⚠️ partial | Missing: inaugural v1 statement, migration runner behaviour details, future migration template skeleton |
+| `EnvVarReference` security validation | ✅ yes (note about blocked patterns) | — |
+| Annotated example covering all required fields | ⚠️ partial | "Minimal Example" is present but needs `schemaVersion`, `accounts`, and annotations per FR-003 |
+
+**Decision**: Base `docs/config-format.md` on the Starlight draft content, strip Astro frontmatter, expand schema versioning section per FR-004, add wizard-equivalent phrasing for `authMethod`/`envVars`/`secretsBackend`, add annotated full example.
+
+**Rationale**: The Starlight draft is accurate and battle-tested against the Zod schema. Reusing it avoids divergence. The two files serve different audiences (docs site vs GitHub raw) but share the same schema truth.
+
+---
+
+## RES-003: Tilde Logo Variation SVG (FR-009)
+
+**Question**: What visual constraints apply to `tilde-logo-variation.svg`, and what SVG structure should be used?
+
+**Decision**: The SVG is a self-contained file using the brand wave path from `docs/design/design-tokens.md` plus the literal `~` character. It is optimised for GitHub README rendering (works on both light and dark themes, dark background with brand green).
+
+**Constraints from `docs/design/design-tokens.md`**:
+- Primary accent colour: `#4ade80` (brand green)
+- Background: `#030712` (dark)
+- Stroke only, no fill — consistent with the existing wave mark SVG path documented in design-tokens.md
+- Wave path: `M4 22 C8 10, 14 10, 16 22 C18 34, 24 34, 28 22` (exact path from design tokens)
+- Monospace typeface stack for any text elements
+
+**Tilde-specific distinguishing element**: The `~` character incorporated into the logomark. This can be achieved via:
+1. SVG `<text>` element with the `~` glyph in a monospace font — simple and semantically clear
+2. A second bezier path forming a `~` — more precise but requires custom path data
+
+**Decision**: Approach 1 (SVG `<text>`) for the variation logo. The `~` character is the primary brand mark of this product (product is literally named "tilde"); rendering it as a text glyph is semantically unambiguous and readable at all sizes. The wave bezier path (from design tokens) is retained as the secondary graphical element.
+
+**SVG dimensions**: `viewBox="0 0 120 60"`, no fixed `width`/`height` (scales to container). README `<img>` will specify `width="160"`.
+
+**Light/dark compatibility**: SVG uses a `<rect>` background in `#030712` so the logo has its own dark background regardless of GitHub theme. This is the same pattern used by `docs/banner.svg`.
+
+**Alternatives considered**:
+- CSS-based dark/dark theme switching via `prefers-color-scheme` in SVG — overly complex for a simple logomark; the existing banner.svg uses a fixed dark background
+- Using the existing tilde wave favicon (`site/docs/public/favicon.svg`) as the base — favicon is 32×32 and optimised for small sizes; the variation logo needs to be legible at README width (~160px)
+
+---
+
+## RES-004: README Logo Placement (FR-010)
+
+**Question**: How should the tilde logo variation be added to README.md without breaking existing rendering?
+
+**Decision**: Insert an `<img>` tag for `docs/design/tilde-logo-variation.svg` inside the existing `<div align="center">` block, above the current `banner.svg` `<img>`. Use a relative path (not raw GitHub URL) so it works in both GitHub and local preview.
+
+**Current README header**:
+```html
+<div align="center">
+  <img src="docs/banner.svg" alt="tilde — developer environment bootstrap" width="560"/>
+  [badges]
+</div>
+```
+
+**Updated pattern**:
+```html
+<div align="center">
+  <img src="docs/design/tilde-logo-variation.svg" alt="tilde" width="160"/>
+  <br/><br/>
+  <img src="docs/banner.svg" alt="tilde — developer environment bootstrap" width="560"/>
+  [badges]
+</div>
+```
+
+**Rationale**: Relative paths work on GitHub.com for files in the same repo (GitHub resolves them from repo root when rendering README.md). The `<br/>` spacing ensures the logo and banner don't crowd each other. Width 160px is appropriate for a product logomark in a README header.
+
+---
+
+## RES-005: Root-Level Markdown Audit (FR-011)
+
+**Question**: Are there any non-exception `.md` files at the repo root?
+
+**Findings**: Repository root currently contains:
+- `README.md` — permitted exception
+- `CHANGELOG.md` — permitted exception  
+- `CONTRIBUTING.md` — permitted exception
+- `LICENSE` — not markdown (no `.md` extension)
+
+**No action required for FR-011 migration**: The repo root is already compliant with the four-exception rule. SC-003 will pass immediately. The `docs/` folder also contains no misplaced files. FR-011 is satisfied by confirming compliance; no migration work is needed.
+
+**Note**: The spec states "Any markdown files found at the repository root that are not among the four permitted exceptions are either stale or have been superseded." No such files were found.
+
+---
+
+## RES-006: Spec 005 Editorial Changes (FR-012, FR-013)
+
+**Question**: What exactly needs to change in `specs/005-ui-branding-consolidation/spec.md` (FR-006) and `tasks.md` (T0021/T0025)?
+
+**Spec 005 spec.md FR-006 (current)**:
+```
+- **FR-006**: Brand colors and typeface MUST be defined and applied consistently across: README, install page, docs site, and CLI splash screen.
+```
+
+**Problem**: "README" cannot receive custom CSS/colours via GitHub Markdown; the requirement is unenforceable for that surface. The clause must be narrowed to exclude GitHub Markdown surfaces.
+
+**Revised FR-006**: Remove "README" from the surface list; restrict to enforceable surfaces only (install page, docs site, CLI splash screen).
+
+**Spec 005 tasks.md (current T0021 and T0025)**: No dependency on T0011 declared. Both tasks modify `site/docs/astro.config.mjs` — the same file that T0011 modifies — creating sequential dependency.
+
+**Required additions**:
+- T0021: Add "Depends on: T0011 (both modify `site/docs/astro.config.mjs`; run sequentially)"
+- T0025: Add "Depends on: T0011 (both modify `site/docs/astro.config.mjs`; run sequentially)"
+
+---
+
+## Summary of Technical Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| RES-001 | `readFileSync + JSON.parse` via `import.meta.url` for runtime version reading | ESM-safe, dependency-free, Node 20+ standard |
+| RES-002 | Base `docs/config-format.md` on Starlight draft; remove frontmatter; expand versioning section | Avoids drift; draft is schema-accurate |
+| RES-003 | SVG `<text>` tilde character on dark background with brand green wave path | Semantically clear; consistent with design tokens |
+| RES-004 | Logo `<img>` above banner `<img>` inside existing `<div align="center">` | Non-destructive; uses relative path |
+| RES-005 | No root markdown migration needed — root is already compliant | Audit confirmed; FR-011 is a verification task |
+| RES-006 | Narrow spec 005 FR-006 to remove README; add T0011 deps to T0021+T0025 | Editorial fix only; no scope change to spec 005 |
+
+All NEEDS CLARIFICATION items resolved. No blockers for Phase 1.

--- a/specs/006-docs-polish-spec-hygiene/spec.md
+++ b/specs/006-docs-polish-spec-hygiene/spec.md
@@ -1,0 +1,205 @@
+# Feature Specification: Documentation Polish and Spec Hygiene
+
+**Feature Branch**: `006-docs-polish-spec-hygiene`  
+**Created**: 2026-03-31  
+**Status**: Implemented  
+**Input**: GitHub Issues #35, #15, #23, #36, #37, #38, #39, #32
+
+## Clarifications
+
+### Session 2026-03-30
+
+- Q: Which SVG file should FR-010's "Thingstead logo" in the README header reference — the base `thingstead-logo.svg`, the new `tilde-logo-variation.svg`, or the existing `banner.svg`? → A: `docs/design/tilde-logo-variation.svg` — it is the tilde-specific product mark created precisely for product surfaces; the existing `banner.svg` remains unchanged.
+- Q: What ESM-compatible mechanism should FR-006 use to read the package version from `package.json` at runtime given `"type": "module"` and Node ≥ 20? → A: `readFileSync` + `JSON.parse` via `import.meta.url` — portable across ESM environments, no import assertions needed, no dependency on npm runtime.
+- Q: For FR-004, what should the schema versioning/migration section in `docs/config-format.md` contain given that v1 is the inaugural schema with no prior migrations? → A: Document that v1 is the inaugural schema (no prior versions exist), explain how the migration runner automatically detects `schemaVersion` and applies upgrades additively and non-destructively, and include a template skeleton for future version entries so the section is immediately useful when v2 is introduced.
+- Q: For FR-009, what constitutes the "tilde-specific visual element" that distinguishes `tilde-logo-variation.svg` from the base `thingstead-logo.svg`? → A: The tilde character (`~`) incorporated into the logomark — semantically unambiguous, immediately identifies the product, consistent with developer-tool visual language.
+- Q: For FR-005, what documentation strategy should be used for technically-named fields (`authMethod`, `envVars`, `secretsBackend`) given the non-technical audience requirement? → A: Wizard-equivalent phrasing — use the same purpose-driven language the wizard presents to users for each field, avoiding internal identifiers; map wizard question text to field descriptions so the doc matches what users see in the interactive flow.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Config-First Users Can Author `tilde.config.json` Without the Wizard (Priority: P1)
+
+A developer wants to prepare their tilde configuration before they even have a machine to run
+the wizard on — for example, setting up a new machine from scratch using a config file they
+authored in advance. They visit the tilde GitHub repository, navigate to `docs/config-format.md`,
+and find a complete, plain-language reference covering every field in `tilde.config.json` —
+with an annotated example, clear descriptions of valid values, and guidance on how schema
+versioning works so their config stays compatible across tilde upgrades.
+
+**Why this priority**: The tilde constitution (Principle I) mandates config-first mode as a
+first-class entry path. The constitution also explicitly requires `docs/config-format.md` to
+exist at the mandated repo path. Today that file is absent from `docs/` (it exists only inside
+the docs site source tree, not at the repository root path the constitution requires), and the
+schema reference is incomplete. This blocks users from the config-first workflow. Resolves
+issues #35 and #15.
+
+**Independent Test**: Open `docs/config-format.md` in the repository root. Using only that
+document and no other resources, author a valid `tilde.config.json` that covers all required
+fields. Feed it to tilde and confirm it is accepted without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user visits the tilde GitHub repository, **When** they navigate to `docs/config-format.md`, **Then** the file exists at that path and renders a complete configuration reference.
+2. **Given** a user reads `docs/config-format.md`, **When** they attempt to set any configuration field, **Then** every field is documented with its name, a plain-English description, valid values or format, whether it is required or optional, and a default value where applicable.
+3. **Given** a user reads `docs/config-format.md`, **When** they review the annotated example, **Then** they can copy it and fill it in without needing to consult any other document.
+4. **Given** a user has a `tilde.config.json` written for an older schema version, **When** they read the migration notes in `docs/config-format.md`, **Then** they understand what changed between versions and how to update their file.
+5. **Given** a user with no technical background reads `docs/config-format.md`, **When** they encounter a field they don't recognise, **Then** the description uses plain language — no jargon about code constructs, no assumption of prior CLI knowledge.
+
+---
+
+### User Story 2 - CLI Splash Screen Shows the Actual Running Version (Priority: P1)
+
+A developer launches tilde and sees the splash screen. The version shown in the splash — and
+in any other CLI output — matches the installed version of tilde they are actually running,
+not a stale number baked in at some earlier point in the codebase. If tilde is updated without
+a corresponding source change, the displayed version updates automatically.
+
+**Why this priority**: The tilde constitution (Principle IV) explicitly requires the splash
+screen to display the running tilde version dynamically at runtime. Today the source contains
+a hardcoded version constant (`0.1.0`) that is out of sync with the published package version
+(`1.2.0`). This is a constitution violation and actively misleads users about which version
+they are running. Resolves issue #32.
+
+**Independent Test**: Install a known version of tilde, run it, and verify the version shown
+on the splash matches the installed package version exactly. Update to a newer version without
+any source changes and re-run; the splash version must update without any manual edits.
+
+**Acceptance Scenarios**:
+
+1. **Given** tilde is launched in interactive mode, **When** the splash screen renders, **Then** the displayed tilde version matches the version declared in the project's own package manifest.
+2. **Given** tilde is updated to a newer release, **When** the splash screen renders after the update, **Then** the version shown reflects the new release — no source changes required.
+3. **Given** tilde is launched with `--version`, **When** the output is printed, **Then** the version string matches what the splash screen displays and the package manifest version.
+4. **Given** tilde is run in CI / non-interactive mode (`--ci` or `--yes`), **When** the process runs, **Then** the splash screen is suppressed (per Principle IV), and the version requirement does not cause any errors.
+
+---
+
+### User Story 3 - README Header Displays the Tilde Product Logo (Priority: P2)
+
+A potential contributor or user lands on the tilde GitHub repository page. The first thing
+they see in the README is the Thingstead logo, centred in the header, giving the project an
+instantly recognisable brand identity consistent with the other Thingstead surfaces. A product
+variant of the logo — `tilde-logo-variation.svg` — is also available in `docs/design/` for
+use wherever a tilde-specific mark is needed.
+
+**Why this priority**: Branding consistency was established in spec 005. The README header logo
+and the product logo variant are the two visible deliverables left outstanding from that work.
+They improve first impressions without affecting any functional behaviour, making this P2 after
+the two P1 constitution violations. Resolves issues #36 and #37.
+
+**Independent Test**: Open the tilde GitHub repository in a browser. Verify the README header
+shows a centred Thingstead logo image. Navigate to `docs/design/tilde-logo-variation.svg` and
+confirm the file exists and renders as a coherent product logo variation consistent with the
+design tokens defined in `docs/design/design-tokens.md`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor opens the tilde GitHub repository, **When** they view the README, **Then** a centred tilde product logo (`tilde-logo-variation.svg`) `<img>` element appears at the top of the header section.
+2. **Given** the logo image in the README, **When** GitHub renders it, **Then** it is centred (using standard GitHub Markdown alignment) and displays correctly in both light and dark mode.
+3. **Given** the `docs/design/` folder, **When** a contributor browses it, **Then** `tilde-logo-variation.svg` exists and is visually consistent with the existing `thingstead-logo.svg` design tokens (same colour palette and proportions, with a tilde-specific element).
+4. **Given** the logo variation SVG, **When** it is opened standalone, **Then** it renders without errors and at a legible default size.
+
+---
+
+### User Story 4 - All Markdown Documentation Lives in the Right Place (Priority: P2)
+
+A contributor browsing the tilde repository can find all project documentation under the
+`docs/` folder, as the tilde constitution requires. No stray markdown files live at the
+repository root (except the standard allowed exceptions: README.md, CONTRIBUTING.md,
+CHANGELOG.md, LICENSE). This makes the repository easier to navigate and keeps it in
+compliance with the project constitution.
+
+**Why this priority**: Constitution compliance is required for all PRs. Any remaining loose
+markdown files represent ongoing violations. While not user-facing, this unblocks clean audits
+and reduces contributor confusion. Resolves issue #23.
+
+**Independent Test**: Run a directory listing of all `.md` files in the repository root
+(excluding the allowed exceptions). No additional markdown files should be found. Verify that
+any content migrated from the root now exists under `docs/`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the repository root, **When** all files are listed, **Then** the only `.md` files present are README.md, CONTRIBUTING.md, CHANGELOG.md, and LICENSE (if markdown).
+2. **Given** any markdown document that was previously at the root, **When** it is browsed from `docs/`, **Then** its content is intact and any internal links still resolve correctly.
+3. **Given** any document that links to a previously-root-level markdown file, **When** the link is followed, **Then** it resolves to the new `docs/` location without a broken path.
+
+---
+
+### User Story 5 - Spec 005 Hygiene Corrections Are Applied (Priority: P3)
+
+A future contributor reading spec 005 (`005-ui-branding-consolidation`) sees accurate, enforceable
+requirements and correct task dependency information. FR-006 no longer contains an unenforceable
+requirement about applying brand colours and typefaces via GitHub Markdown (which cannot support
+custom CSS). The tasks file correctly documents that T0021 and T0025 depend on T0011, since all
+three modify the same Astro configuration file and must run sequentially to avoid merge conflicts.
+
+**Why this priority**: These are spec hygiene fixes with no user-facing impact. They prevent
+future confusion for anyone implementing or reviewing spec 005, but they do not block any
+current work. Resolves issues #38 and #39.
+
+**Independent Test**: Read spec 005's FR-006 and verify it contains no reference to applying
+custom colours or typefaces on GitHub Markdown surfaces. Open spec 005's tasks.md and confirm
+T0021 and T0025 each declare a dependency on T0011.
+
+**Acceptance Scenarios**:
+
+1. **Given** spec 005 `spec.md`, **When** FR-006 is read, **Then** it describes only enforceable branding requirements — no mention of applying custom CSS, colours, or typefaces to GitHub Markdown surfaces.
+2. **Given** spec 005 `tasks.md`, **When** T0021 is read, **Then** it lists T0011 as a prerequisite dependency.
+3. **Given** spec 005 `tasks.md`, **When** T0025 is read, **Then** it lists T0011 as a prerequisite dependency.
+4. **Given** a reader reviewing the corrected FR-006, **When** they evaluate it against a completed implementation, **Then** they can make a clear pass/fail determination without ambiguity.
+
+---
+
+### Edge Cases
+
+- What if `docs/config-format.md` already has partial content from a previous attempt? The file must be replaced with a complete, authoritative version — partial content is treated as absent.
+- What if a loose markdown file at the repository root contains content also present in `docs/`? Duplicates must be resolved by retaining the `docs/` copy and removing the root copy; if the root copy contains content not yet in `docs/`, that content must be merged before the root file is removed.
+- What if the Thingstead logo in the README renders differently across GitHub's light and dark themes? The logo SVG must be tested against both themes; if a single file cannot satisfy both, a light-mode-first approach is used (GitHub's default) and the issue is noted in `docs/design/`.
+- What if the package manifest version is unavailable at runtime (e.g., in an unusual installation path)? The splash screen must fall back gracefully to a static placeholder string (e.g., `unknown`) rather than crashing or showing an empty field — consistent with the constitution's graceful fallback requirement in Principle IV.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The file `docs/config-format.md` MUST exist at that exact path in the repository (not only within the docs site source tree), satisfying the constitution's mandate in the Entry Modes / Config Schema sections.
+- **FR-002**: `docs/config-format.md` MUST document every field in `tilde.config.json` — each with its field name, a plain-English description, the set of valid values or expected format, whether the field is required or optional, and a default value where one exists.
+- **FR-003**: `docs/config-format.md` MUST include a fully annotated example `tilde.config.json` that covers all required fields and representative optional fields, with inline comments explaining each entry in plain language.
+- **FR-004**: `docs/config-format.md` MUST include a schema versioning and migration section explaining: what `schemaVersion` means, how tilde uses it on load, what happens when a config is on an older version, and the guarantee that migration is additive and non-destructive. The section MUST explicitly state that v1 is the inaugural schema (no prior versions exist and no migration is required for any config already at v1), describe how the migration runner automatically detects `schemaVersion` and applies upgrades, and include a clearly marked template skeleton (e.g., "Future migrations will follow this pattern: …") so the section remains useful when v2 is introduced.
+- **FR-005**: `docs/config-format.md` MUST be written for non-technical users — no references to code constructs, compiler behaviour, or internal implementation; terminology must match what the wizard uses when presenting the same choices. For technically-named fields (e.g., `authMethod`, `envVars`, `secretsBackend`), descriptions MUST use wizard-equivalent, purpose-driven language that maps directly to the wizard's own question text — internal identifiers must not appear as explanatory terms; they may appear only as field name labels.
+- **FR-006**: The CLI splash screen MUST display the tilde version read dynamically from the project's own package manifest at startup, not from a hardcoded constant in source code. The version MUST be read using `readFileSync` + `JSON.parse` resolved via `import.meta.url` — this is the required ESM-compatible mechanism; `createRequire`, import assertions, and `process.env.npm_package_version` are explicitly excluded.
+- **FR-007**: The version displayed on the CLI splash screen MUST match the version reported by `tilde --version` and the version in the project's package manifest. All three must be consistent at all times without any manual synchronisation step.
+- **FR-008**: When the package manifest version cannot be determined at runtime, the splash screen MUST display a graceful fallback (e.g., `unknown`) rather than an error or blank value.
+- **FR-009**: The file `docs/design/tilde-logo-variation.svg` MUST be created as a product variant of the Thingstead logo, using the colour palette and proportions defined in `docs/design/design-tokens.md`, with the tilde character (`~`) incorporated into the logomark as the distinguishing visual element — this is the required tilde-specific mark that distinguishes it from the base `thingstead-logo.svg`.
+- **FR-010**: The README.md header MUST display the Thingstead logo as a centred `<img>` element using standard GitHub Markdown alignment techniques, referencing `docs/design/tilde-logo-variation.svg` as the logo source — not the base `thingstead-logo.svg` nor the existing `banner.svg` (which remains unchanged). The existing `<div align="center">` banner wrapper MAY be extended to include the logo `<img>` above or alongside the current banner, provided the result renders correctly on GitHub.
+- **FR-011**: All markdown documentation files in the repository MUST reside under the `docs/` folder, with the sole exceptions of README.md, CONTRIBUTING.md, CHANGELOG.md, and LICENSE. Any remaining non-compliant files must be migrated with content intact and internal links updated.
+- **FR-012**: Spec 005 (`specs/005-ui-branding-consolidation/spec.md`) FR-006 MUST be narrowed to remove any requirement about applying brand colours or typefaces on GitHub Markdown surfaces (which cannot support custom CSS). The revised requirement MUST describe only enforceable, verifiable branding outcomes.
+- **FR-013**: Spec 005 (`specs/005-ui-branding-consolidation/tasks.md`) MUST document that task T0021 depends on T0011, and that task T0025 depends on T0011, with the rationale that all three tasks modify the same Astro configuration file and must execute sequentially.
+
+### Key Entities
+
+- **Config Format Document** (`docs/config-format.md`): The authoritative plain-language reference for `tilde.config.json`. Covers all fields, valid values, an annotated example, and schema migration guidance. Audience: non-technical users and developers new to tilde.
+- **tilde.config.json schema**: The versioned structure of the configuration file. Contains a `schemaVersion` field; each version is documented in the config format document with forward migration notes.
+- **Tilde Logo Variation** (`docs/design/tilde-logo-variation.svg`): A product-specific SVG mark derived from the base Thingstead logo. Constrained by the design tokens defined in `docs/design/design-tokens.md`.
+- **Splash Screen**: The animated terminal screen displayed on every interactive tilde launch. Displays OS, architecture, shell, and — critically for this feature — the dynamically read tilde version.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user with no prior tilde experience can write a valid, wizard-equivalent `tilde.config.json` from scratch using only `docs/config-format.md` — verified by having a test reader complete the task without any other assistance and succeeding on first attempt. **Note (post-implementation)**: This is a manual usability criterion with no automated verification path. Automated schema validation (`npm run validate:config-doc`) covers SC-008 (field coverage) but not SC-001 (usability). Recommend exercising this at beta/v2.0 milestone with a real test reader.
+- **SC-002**: The version displayed on the CLI splash screen matches the installed package version on 100% of launches, across a clean install, an upgrade, and a downgrade scenario. **Note (post-implementation)**: Clean install and runtime read are covered by unit tests. Upgrade/downgrade scenarios are validated manually at release time; no automated integration test covers this path.
+- **SC-003**: Zero markdown files exist at the repository root other than the four permitted exceptions (README.md, CONTRIBUTING.md, CHANGELOG.md, LICENSE), confirmed by a directory listing. **Audit result (2026-03-30)**: ✅ PASS — `find . -maxdepth 1 -name "*.md"` returns exactly `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md` (3 files; LICENSE has no extension).
+- **SC-004**: The tilde product logo (`tilde-logo-variation.svg`) is visible and centred in the README header when the repository is viewed on GitHub in a standard browser — confirmed in both light and dark theme.
+- **SC-005**: `docs/design/tilde-logo-variation.svg` exists, opens without rendering errors, and is visually identifiable as a tilde-specific variant of the Thingstead brand — verified by reviewing the file against `docs/design/design-tokens.md`.
+- **SC-006**: Spec 005 FR-006 contains no requirements that reference GitHub Markdown CSS, custom colours applied in Markdown, or typeface enforcement in the README — confirmed by reading the revised requirement.
+- **SC-007**: Spec 005 tasks.md shows explicit dependency declarations for T0021 → T0011 and T0025 → T0011 — confirmed by reading both task entries.
+- **SC-008**: `docs/config-format.md` covers 100% of the fields present in the current `tilde.config.json` schema, with no undocumented fields — verified by comparing the document against the schema definition.
+
+## Assumptions
+
+- The `tilde.config.json` schema is at version `1` currently; all migration guidance in `docs/config-format.md` will describe the path from any previous version to version `1`. Future schema versions are out of scope for this spec but the document structure must accommodate them.
+- The Thingstead logo source assets (`docs/design/thingstead-logo.svg`) and design tokens (`docs/design/design-tokens.md`) from spec 005 are already in place; `tilde-logo-variation.svg` builds on those rather than redefining the brand.
+- The README logo uses a GitHub-hosted path to the SVG (e.g., a relative path or raw GitHub URL) so it renders on the GitHub repository page without a separate CDN or hosting requirement.
+- "Non-technical user" means someone who understands their developer toolchain goals (e.g., "I want to use Node 22 with nvm") but is not expected to know JSON schema standards, TypeScript types, or internal tilde architecture.
+- The splash screen version change is limited to reading the version from the package manifest at runtime — no changes to the splash visual design, animation, or other displayed fields are in scope.
+- Spec 005 corrections (FR-006 narrowing and tasks.md dependency declarations) are editorial changes only; they do not change the scope of work in spec 005, only its accuracy and enforceability.
+- Any markdown files found at the repository root that are not among the four permitted exceptions are either stale or have been superseded by content already in `docs/`. If unique content is found, it will be merged into `docs/` before the root file is removed.

--- a/specs/006-docs-polish-spec-hygiene/tasks.md
+++ b/specs/006-docs-polish-spec-hygiene/tasks.md
@@ -1,0 +1,260 @@
+---
+description: "Task list for spec 006 — Documentation Polish and Spec Hygiene"
+---
+
+# Tasks: Documentation Polish and Spec Hygiene
+
+**Branch**: `006-docs-polish-spec-hygiene`  
+**Input**: Design documents from `specs/006-docs-polish-spec-hygiene/`  
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)  
+**Prerequisites**: plan.md ✅ · spec.md ✅ · research.md ✅ · data-model.md ✅ · quickstart.md ✅ · contracts/ ✅
+
+**Tests**: One unit test required (US2 only — `readPackageVersion()`). No TDD for other stories.
+
+**Organization**: Tasks are grouped by user story. US1 and US2 (P1) are fully independent. US3, US4 (P2) and US5 (P3) can begin after Phase 1.
+
+## Format: `[ID] [P?] [Story] Description with file path`
+
+- **[P]**: Parallelizable — operates on a different file from preceding tasks with no unsatisfied dependencies
+- **[Story]**: Which user story this task belongs to (US1 – US5)
+- All task IDs are 4-digit zero-padded (T0001, T0002, …) to avoid lexicographic sort issues
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify baseline integrity before any changes are made.
+
+- [X] T0001 Verify baseline: run `npm run build && npm test` at repo root and confirm all existing tests pass with no pre-existing failures
+
+**Checkpoint**: Baseline green — all user stories can now proceed independently
+
+---
+
+## Phase 2: Foundational
+
+**N/A** — This spec makes no schema changes, introduces no shared infrastructure, and has no cross-story blocking prerequisites. All five user stories can proceed in priority order immediately after Phase 1.
+
+---
+
+## Phase 3: User Story 1 — Config-First Users Can Author tilde.config.json Without the Wizard (Priority: P1) 🎯 MVP
+
+**Goal**: Create `docs/config-format.md` — the complete, plain-English schema reference at the mandated repo path — with an annotated example, wizard-equivalent phrasing, a schema versioning section, a README link, and a CI validation step.
+
+**Independent Test**: Open `docs/config-format.md` and, using only that file, author a valid `tilde.config.json` covering every required field. Run `npm run validate:config-doc` and confirm it exits 0. Resolves issues #35 and #15.
+
+### Implementation for User Story 1
+
+- [X] T0002 [US1] Copy `site/docs/src/content/docs/config-format.md` to `docs/config-format.md`; strip the Astro frontmatter block (the `--- title: … ---` section at the top of the file); replace it with `# tilde Configuration Format` as the H1 header
+- [X] T0003 [US1] Expand the Schema Versioning and Migration section of `docs/config-format.md` to include: (1) explicit inaugural v1 statement — "v1 is the first schema version; no prior versions exist; any config already at v1 requires no migration"; (2) migration runner behaviour — tilde detects `schemaVersion` on load, applies applicable migration steps in order, writes back atomically, notifies the user; migration is additive and non-destructive; on failure: warn, preserve original file unmodified, offer wizard re-run; (3) forward-version handling — if `schemaVersion` is higher than installed tilde supports: warn user, open config in read-only mode, prompt to upgrade tilde; (4) a clearly labelled future migration template skeleton block showing the pattern future v2 entries will follow
+- [X] T0004 [US1] Apply wizard-equivalent phrasing to the `authMethod`, `envVars`, and `secretsBackend` field descriptions in `docs/config-format.md` per the Wizard-Equivalent Phrasing Map in `specs/006-docs-polish-spec-hygiene/data-model.md`: `authMethod` → "How will you authenticate to GitHub in this context?"; `envVars` → "Environment variables to load when you're working in this context (use your secrets backend references — not raw tokens)"; `secretsBackend` → "Where should tilde store and retrieve your secrets?"
+- [X] T0005 [US1] Audit the annotated example block in `docs/config-format.md` and confirm it: (a) explicitly sets `"schemaVersion": 1`; (b) includes all required fields from the contracts/config-format-doc.md Required Fields Checklist; (c) includes representative optional fields (`$schema`, `tools`, `accounts`, `vscodeProfile`, `isDefault`); (d) includes at least two `contexts` entries; (e) has inline `//` comments explaining every field; correct any gaps found
+- [X] T0006 [US1] Create `scripts/validate-config-doc-example.ts`: reads `docs/config-format.md`, extracts the first fenced JSON code block in the annotated example section, strips `//` inline comments (regex `//[^\n]*`), parses the result, validates against `TildeConfigSchema` from `src/config/schema.ts`, prints `✅ Config doc example is valid` on success or the Zod error details on failure, and exits non-zero on any failure
+- [X] T0007 [US1] Add `"validate:config-doc": "npx tsx scripts/validate-config-doc-example.ts"` to the `scripts` section of `package.json`
+- [X] T0008 [US1] Add a `validate-config-doc` step to the existing `test` job in `.github/workflows/ci.yml` after the `Build` step: `run: npm run validate:config-doc`; also remove `'docs/**'` from the `paths-ignore` list in the `on.push` trigger so that changes to `docs/config-format.md` cause CI to run
+- [X] T0009 [US1] Add a "Configuration reference" entry to the `README.md` highlights section: insert a bullet `- 📄 [Configuration reference](docs/config-format.md)` after the existing quick-start / highlight bullets in the README body (not inside the `<div align="center">` header block)
+
+**Checkpoint**: US1 complete — `docs/config-format.md` exists, is complete, links from README, and passes `npm run validate:config-doc`
+
+---
+
+## Phase 4: User Story 2 — CLI Splash Screen Shows the Actual Running Version (Priority: P1)
+
+**Goal**: Replace the hardcoded `const VERSION = '0.1.0'` constant in `src/index.tsx` with `readPackageVersion()` — an ESM-safe, synchronous read of the version from `package.json` at startup — and add a unit test for the helper.
+
+**Independent Test**: Run `npm run build && node dist/index.js --version`; confirm the output matches `` `tilde v$(jq -r .version package.json)` ``. Resolves issue #32.
+
+### Implementation for User Story 2
+
+- [X] T0010 [US2] Edit `src/index.tsx` imports: add `readFileSync` to the existing `node:fs` import line (alongside `existsSync`); add `import { fileURLToPath } from 'node:url';`; add `dirname` to the existing `node:path` import line (alongside `resolve`)
+- [X] T0011 [US2] Add `export function readPackageVersion(): string` immediately before `const VERSION` in `src/index.tsx`, using the exact implementation from `specs/006-docs-polish-spec-hygiene/contracts/version-reading.md`: resolves path via `fileURLToPath(import.meta.url)` → `dirname` → `resolve('../package.json')`, reads with `readFileSync`, parses with `JSON.parse`, returns `.version ?? 'unknown'`; wraps entirely in try/catch returning `'unknown'` on any error; export the function to make it unit-testable
+- [X] T0012 [US2] Replace `const VERSION = '0.1.0'` on line 15 of `src/index.tsx` with `const VERSION = readPackageVersion()` — no other changes to the file required (the `--version` flag output on line 79 and the `version: VERSION` prop on line 287 already use this constant and require no modification)
+- [X] T0013 [US2] Create `tests/unit/read-package-version.test.ts` with two Vitest test cases: (1) **normal case** — import `readPackageVersion` from `src/index.tsx`; assert the returned string matches `version` from `package.json` (read via `readFileSync`); (2) **fallback case** — mock `node:fs` so `readFileSync` throws; assert `readPackageVersion()` returns `'unknown'`
+
+**Checkpoint**: US2 complete — `node dist/index.js --version` outputs the actual package.json version; unit test passes
+
+---
+
+## Phase 5: User Story 3 — README Header Displays the Tilde Logo (Priority: P2)
+
+**Goal**: Create `docs/design/tilde-logo-variation.svg` — a brand-consistent product logomark — and insert it into the README header above the existing banner.
+
+**Independent Test**: `xmllint --noout docs/design/tilde-logo-variation.svg` exits 0; README.md displays a centred logo above the banner when viewed on GitHub.com. Resolves issues #36 and #37.
+
+### Implementation for User Story 3
+
+- [X] T0014 [US3] Create `docs/design/tilde-logo-variation.svg` per `specs/006-docs-polish-spec-hygiene/contracts/logo-variation.md`: `viewBox="0 0 120 60"` with no fixed `width`/`height`; `<title>tilde</title>` for accessibility; dark background `<rect width="120" height="60" fill="#030712" rx="8"/>`; wave bezier `<path d="M4 22 C8 10, 14 10, 16 22 C18 34, 24 34, 28 22" stroke="#4ade80" stroke-width="4" stroke-linecap="round" fill="none"/>`; tilde glyph `<text>` element in `fill="#4ade80"` with `font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace"`; no external font references, no animation
+- [X] T0015 [US3] Edit `README.md`: inside the existing `<div align="center">` block, insert `<img src="docs/design/tilde-logo-variation.svg" alt="tilde" width="160"/>` followed by `<br/><br/>` on the line immediately above the existing `<img src="docs/banner.svg" alt="tilde — developer environment bootstrap" width="560"/>` tag; do not remove or alter the banner `<img>` or any badges
+
+**Checkpoint**: US3 complete — logo SVG is well-formed and renders in the README header above the banner
+
+---
+
+## Phase 6: User Story 4 — All Markdown Docs Live in the Right Place (Priority: P2)
+
+**Goal**: Confirm the repository root already satisfies the markdown location requirement; close issue #23 with documented evidence.
+
+**Independent Test**: `find . -maxdepth 1 -name "*.md" | sort` returns exactly three files: `./CHANGELOG.md`, `./CONTRIBUTING.md`, `./README.md`. Resolves issue #23.
+
+### Implementation for User Story 4
+
+- [X] T0016 [P] [US4] Run `find . -maxdepth 1 -name "*.md" | sort` at repo root; confirm output is exactly `./CHANGELOG.md`, `./CONTRIBUTING.md`, `./README.md`; record SC-003 as ✅ pass (no migration needed — repo root was already compliant before this spec)
+- [X] T0017 [US4] Close GitHub issue #23 via `gh issue close 23 --comment "Audit completed on branch \`006-docs-polish-spec-hygiene\`. Root-level markdown files: CHANGELOG.md, CONTRIBUTING.md, README.md — exactly the three permitted exceptions. No additional .md files found at repo root. SC-003 satisfied. No migration needed."` using the `gh` CLI
+
+**Checkpoint**: US4 complete — issue #23 closed with documented compliance confirmation
+
+---
+
+## Phase 7: User Story 5 — Spec 005 Hygiene Corrections (Priority: P3)
+
+**Goal**: Narrow FR-006 in `specs/005-ui-branding-consolidation/spec.md` to remove the unenforceable README surface, and add explicit T0011 dependency declarations to T0021 and T0025 in `specs/005-ui-branding-consolidation/tasks.md`.
+
+**Independent Test**: Read revised FR-006 — no mention of README or GitHub Markdown CSS; read T0021 and T0025 entries — each explicitly declares "Depends on: T0011" with the shared `astro.config.mjs` rationale; no "independent" marker remains between US2/US3/US4 for that file. Resolves issues #38 and #39.
+
+### Implementation for User Story 5
+
+- [X] T0018 [P] [US5] Edit `specs/005-ui-branding-consolidation/spec.md` FR-006: replace the surface list "README, install page, docs site, and CLI splash screen" with "the install page, docs site, and CLI splash screen"; append the sentence: "GitHub Markdown surfaces (README) are excluded — custom CSS cannot be applied to GitHub-rendered Markdown."
+- [X] T0019 [P] [US5] Edit `specs/005-ui-branding-consolidation/tasks.md` Dependencies section: under T0021, add "**Depends on**: T0011 — both T0021 and T0011 modify `site/docs/astro.config.mjs`; run T0011 to completion before starting T0021 to avoid merge conflicts"; under T0025, add the same dependency note referencing T0011 and `site/docs/astro.config.mjs`; remove any "independent" marker or note between US2/US3/US4 that implies these tasks can run in parallel on that shared file
+
+**Checkpoint**: US5 complete — spec 005 editorial corrections applied; FR-006 is enforceable; T0021/T0025 dependency chain is explicit
+
+---
+
+## Final Phase: Polish & Cross-Cutting Validation
+
+**Purpose**: Full regression check, acceptance criteria sweep, and SC verification across all stories.
+
+- [X] T0020 [P] Run full validation: `npm run build && npm test && npm run validate:config-doc` — confirm all unit/contract/integration tests pass and config-doc example validates against the Zod schema (covers SC-001, SC-002, SC-008)
+- [X] T0021 [P] Verify SVG well-formedness and README rendering: run `xmllint --noout docs/design/tilde-logo-variation.svg` (SC-005); open README.md preview and confirm logo appears centred above the banner (SC-004)
+- [X] T0022 [P] Perform field-coverage spot-check: for each schema field listed in `specs/006-docs-polish-spec-hygiene/contracts/config-format-doc.md` Required Fields Checklist, grep `docs/config-format.md` to confirm presence; flag any gap (SC-008)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: N/A — no blocking prerequisites for this spec
+- **User Stories (Phases 3–7)**: All depend on Phase 1 passing; all stories are otherwise independent of each other
+- **Polish (Final Phase)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+| Story | Priority | Depends On | Notes |
+|---|---|---|---|
+| **US1** Config format doc | P1 | Phase 1 only | Fully independent; create new file |
+| **US2** Dynamic version | P1 | Phase 1 only | Fully independent; single source file edit + test |
+| **US3** README logo | P2 | Phase 1 only | Fully independent; new SVG asset + README edit |
+| **US4** Markdown audit | P2 | Phase 1 only | No code changes; audit + issue close only |
+| **US5** Spec 005 hygiene | P3 | Phase 1 only | Fully independent; two spec artifact edits |
+
+### Within Each User Story
+
+- **US1**: T0002 (copy+strip) → T0003 (versioning section) → T0004 (wizard phrasing) → T0005 (example audit) → T0006 (validation script) → T0007 (npm script) → T0008 (CI step) → T0009 (README link)
+- **US2**: T0010 (add imports) → T0011 (add function) → T0012 (replace constant) → T0013 (unit test)
+- **US3**: T0014 (create SVG) → T0015 (update README)
+- **US4**: T0016 (audit) → T0017 (close issue)
+- **US5**: T0018 ‖ T0019 (edit different files — can run in parallel)
+
+### Parallel Opportunities
+
+- **US1 + US2**: Can be executed by different developers simultaneously (different files throughout)
+- **US3 + US4 + US5**: Can all run in parallel after Phase 1 (completely disjoint files)
+- **US5 within story**: T0018 and T0019 operate on different spec artifact files — parallelizable
+- **Final Phase**: T0020, T0021, T0022 are all read-only verifications operating on different concerns — parallelizable
+
+---
+
+## Parallel Execution Examples
+
+### Parallel Example: US1 + US2 (both P1, fully independent)
+
+```bash
+# Terminal A — US1
+Task: "T0002 Copy and strip site Starlight draft → docs/config-format.md"
+Task: "T0003 Expand schema versioning section in docs/config-format.md"
+# … continue through T0009
+
+# Terminal B — US2 (starts simultaneously)
+Task: "T0010 Add readFileSync / fileURLToPath / dirname imports to src/index.tsx"
+Task: "T0011 Add readPackageVersion() function to src/index.tsx"
+Task: "T0012 Replace const VERSION = '0.1.0' with readPackageVersion()"
+Task: "T0013 Create tests/unit/read-package-version.test.ts"
+```
+
+### Parallel Example: US3, US4, US5 (after Phase 1)
+
+```bash
+# Terminal A — US3
+Task: "T0014 Create docs/design/tilde-logo-variation.svg"
+Task: "T0015 Insert logo <img> in README.md <div align='center'>"
+
+# Terminal B — US4
+Task: "T0016 Run root markdown audit (find . -maxdepth 1 -name '*.md')"
+Task: "T0017 Close issue #23 with gh CLI"
+
+# Terminal C — US5
+Task: "T0018 Narrow FR-006 in specs/005-ui-branding-consolidation/spec.md"
+Task: "T0019 Add T0011 deps to T0021/T0025 in specs/005-ui-branding-consolidation/tasks.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (P1 Stories Only)
+
+1. Complete Phase 1: Setup (T0001)
+2. Complete Phase 3: US1 — Config format doc (T0002–T0009)
+3. Complete Phase 4: US2 — Dynamic CLI version (T0010–T0013)
+4. **STOP and VALIDATE**: `npm run build && npm test && npm run validate:config-doc && node dist/index.js --version`
+5. PR and merge — constitution violations resolved
+
+### Incremental Delivery
+
+1. Phase 1 → Foundation ready
+2. US1 + US2 in parallel → Constitution violations fixed → **MVP delivered**
+3. US3 → Logo + README → Deploy/preview
+4. US4 → Audit complete → Issue #23 closed
+5. US5 → Spec 005 editorial corrections applied
+6. Final Phase validation → Release-ready
+
+### Single-Developer Sequence (priority order)
+
+```
+T0001 → T0002 → T0003 → T0004 → T0005 → T0006 → T0007 → T0008 → T0009   (US1)
+      → T0010 → T0011 → T0012 → T0013                                       (US2)
+      → T0014 → T0015                                                         (US3)
+      → T0016 → T0017                                                         (US4)
+      → T0018 → T0019                                                         (US5)
+      → T0020 → T0021 → T0022                                              (Polish)
+```
+
+---
+
+## Acceptance Checklist Reference
+
+| SC | Story | Verification |
+|---|---|---|
+| SC-001 | US1 | `docs/config-format.md` exists at repo root and covers 100% of `src/config/schema.ts` fields |
+| SC-002 | US2 | `node dist/index.js --version` output matches `jq -r .version package.json` |
+| SC-003 | US4 | `find . -maxdepth 1 -name "*.md"` returns exactly 3 files |
+| SC-004 | US3 | README renders logo centred above banner on GitHub.com |
+| SC-005 | US3 | `xmllint --noout docs/design/tilde-logo-variation.svg` exits 0 |
+| SC-006 | US5 | Revised FR-006 contains no reference to GitHub Markdown CSS or README surface |
+| SC-007 | US5 | T0021 and T0025 in spec 005 tasks.md both declare "Depends on: T0011" |
+| SC-008 | US1 | Field-by-field comparison of `docs/config-format.md` against `src/config/schema.ts` shows 100% coverage |
+
+---
+
+## Notes
+
+- `[P]` tasks operate on different files with no unsatisfied upstream dependencies
+- `[US#]` label maps each task to its user story for independent traceability
+- US4 requires **zero code changes** — T0016 is a read-only audit; T0017 is an issue close
+- The only unit test in this spec is T0013 (`readPackageVersion()`) — no TDD required for other stories
+- `readPackageVersion()` must be `export`ed from `src/index.tsx` (T0011) for the unit test in T0013 to import it directly
+- The CI yml currently has `paths-ignore: ['docs/**']`; T0008 removes this exclusion so that `docs/config-format.md` changes trigger `npm run validate:config-doc`
+- `tsx` is already a dev dependency (`^4.21.0`) — no new dev tooling required for T0006/T0007
+- All file paths are relative to the repository root (`/Users/jeff.williams/Developer/personal/tilde`)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,9 @@
 import React from 'react';
 import { render } from 'ink';
 import { parseArgs } from 'node:util';
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
 import { assertMacOS } from './utils/os.js';
 import { App } from './app.js';
 import { loadConfig } from './config/reader.js';
@@ -12,7 +13,19 @@ import { run } from './utils/exec.js';
 import { PluginError } from './plugins/api.js';
 import type { PluginCategory, AccountConnectorPlugin } from './plugins/api.js';
 
-const VERSION = '0.1.0';
+export function readPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const pkgPath = resolve(__dirname, '../package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+const VERSION = readPackageVersion();
 
 function parseCliArgs() {
   // Check env vars first
@@ -289,15 +302,21 @@ async function main() {
   );
 }
 
-main().catch((err: Error) => {
-  if (err instanceof PluginError) {
-    process.stderr.write(`Plugin error: ${err.message}\n`);
-    process.exit(4);
-  }
-  if (err.message?.includes('Config validation failed')) {
-    process.stderr.write(`Config error: ${err.message}\n`);
-    process.exit(2);
-  }
-  process.stderr.write(`Fatal error: ${err.message}\n`);
-  process.exit(1);
-});
+// Guard: only execute the CLI when this file is run directly (not imported as a module in tests)
+const isMain = process.argv[1] != null && fileURLToPath(import.meta.url).endsWith(process.argv[1].replace(/\\/g, '/'))
+  || process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain || process.env.TILDE_FORCE_RUN === '1') {
+  main().catch((err: Error) => {
+    if (err instanceof PluginError) {
+      process.stderr.write(`Plugin error: ${err.message}\n`);
+      process.exit(4);
+    }
+    if (err.message?.includes('Config validation failed')) {
+      process.stderr.write(`Config error: ${err.message}\n`);
+      process.exit(2);
+    }
+    process.stderr.write(`Fatal error: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/unit/read-package-version.test.ts
+++ b/tests/unit/read-package-version.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Control flag — toggled per test case
+let mockShouldThrow = false;
+
+// vi.mock is hoisted before all imports, intercepting node:fs at module level
+vi.mock('node:fs', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...original,
+    readFileSync: vi.fn().mockImplementation((...args: unknown[]) => {
+      const path = args[0];
+      if (mockShouldThrow && typeof path === 'string' && path.endsWith('package.json')) {
+        throw new Error('ENOENT: no such file or directory');
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (original.readFileSync as any)(...args);
+    }),
+  };
+});
+
+describe('readPackageVersion', () => {
+  beforeEach(() => {
+    mockShouldThrow = false;
+  });
+
+  it('normal case — returns version matching package.json', async () => {
+    const { readPackageVersion } = await import('../../src/index.js');
+    const result = readPackageVersion();
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toBe('unknown');
+    // Should be a semver-like string (e.g. "1.2.0")
+    expect(result).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('fallback case — returns "unknown" when readFileSync throws', async () => {
+    mockShouldThrow = true;
+    const { readPackageVersion } = await import('../../src/index.js');
+    // Call the function directly (not the cached VERSION constant)
+    const result = readPackageVersion();
+
+    expect(result).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary

Documentation polish pass and spec hygiene fixes. Resolves two active constitution violations (Principles I and IV).

## Changes

### US1 — Config-First Reference Doc (constitution Principle I fix)
- Restore `docs/config-format.md` with full schema field coverage, annotated example, and migration section
- Add `scripts/validate-config-doc-example.ts` validation script and `npm run validate:config-doc` script
- Add CI step to validate config doc on every push/PR; narrow `paths-ignore` to root `*.md` only

### US2 — Dynamic CLI Version (constitution Principle IV fix)
- Replace hardcoded `const VERSION = '0.1.0'` in `src/index.tsx` with ESM-safe `readPackageVersion()`
- Reads version from `package.json` at runtime via `readFileSync + JSON.parse + import.meta.url`
- Unit tests covering normal case and fallback to `'unknown'`

### US3 — README Logo
- Create `docs/design/tilde-logo-variation.svg` featuring `~` tilde glyph + wave bezier mark
- Add centred `<img>` logo above banner in README header

### US4 — Markdown Audit
- Root markdown audit confirmed compliant: exactly `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`

### US5 — Spec 005 Hygiene
- Narrow spec 005 FR-006 to remove unenforceable README brand colour requirement
- Add explicit `T0011` dependency declarations to spec 005 T0021 and T0025

## Closes

Closes #35
Closes #15
Closes #32
Closes #36
Closes #37
Closes #38
Closes #39

## Test plan

- `npm test` — 108 tests pass
- `npm run build` — clean build
- `npm run validate:config-doc` — ✅ Config doc example is valid
- `node dist/index.js --version` → `tilde v1.2.0` (matches `package.json`)