### PR TITLE
fix(site): correct favicon path and docs link on landing page

### DIFF
--- a/site/tilde/index.html
+++ b/site/tilde/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="/tilde/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <title>tilde — macOS developer environment, one command away</title>
   <meta name="description" content="tilde configures your entire macOS developer environment from a single config file. One curl command to get started." />
   <script src="https://cdn.tailwindcss.com"></script>
@@ -96,7 +96,7 @@
   <!-- Footer / navigation links -->
   <footer class="border-t border-gray-700 px-4 py-8">
     <div class="max-w-2xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-400">
-      <a href="https://thingstead.io/tilde/docs/getting-started/"
+      <a href="https://tilde.thingstead.io/docs/getting-started/"
          class="flex items-center gap-1.5 text-green-400 hover:text-green-300 transition-colors font-semibold">
         Read the docs
         <span aria-hidden="true">→</span>


### PR DESCRIPTION
## Changes

- **Favicon**: `/tilde/favicon.svg` → `/favicon.svg` (was referencing old monorepo path)
- **Getting Started link**: `thingstead.io/tilde/docs/getting-started/` → `tilde.thingstead.io/docs/getting-started/` (was sending users to old subdomain)

Fixes post-migration issues on `tilde.thingstead.io`.