### PR TITLE
[codex] Phase 03 dotfiles discovery map

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -22,9 +22,9 @@
 
 ### Dotfiles Mapping
 
-- [ ] **DOT-01**: tilde can map known dotfile paths to related tools using the shared metadata registry.
+- [x] **DOT-01**: tilde can map known dotfile paths to related tools using the shared metadata registry.
 - [x] **DOT-02**: tilde can parse common shell rc files for aliases, environment variables, plugin references, and PATH modifications.
-- [ ] **DOT-03**: tilde can look for tool config files in home and workspace context locations without mutating them.
+- [x] **DOT-03**: tilde can look for tool config files in home and workspace context locations without mutating them.
 - [x] **DOT-04**: Dotfile discovery output identifies unknown files separately from known tool-owned files.
 
 ### Provenance Summary
@@ -83,9 +83,9 @@
 | INV-02 | Phase 2 | Complete |
 | INV-03 | Phase 2 | Complete |
 | INV-04 | Phase 2 | Complete |
-| DOT-01 | Phase 3 | Pending |
+| DOT-01 | Phase 3 | Complete |
 | DOT-02 | Phase 3 | Complete |
-| DOT-03 | Phase 3 | Pending |
+| DOT-03 | Phase 3 | Complete |
 | DOT-04 | Phase 3 | Complete |
 | PROV-01 | Phase 4 | Pending |
 | PROV-02 | Phase 4 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -23,9 +23,9 @@
 ### Dotfiles Mapping
 
 - [ ] **DOT-01**: tilde can map known dotfile paths to related tools using the shared metadata registry.
-- [ ] **DOT-02**: tilde can parse common shell rc files for aliases, environment variables, plugin references, and PATH modifications.
+- [x] **DOT-02**: tilde can parse common shell rc files for aliases, environment variables, plugin references, and PATH modifications.
 - [ ] **DOT-03**: tilde can look for tool config files in home and workspace context locations without mutating them.
-- [ ] **DOT-04**: Dotfile discovery output identifies unknown files separately from known tool-owned files.
+- [x] **DOT-04**: Dotfile discovery output identifies unknown files separately from known tool-owned files.
 
 ### Provenance Summary
 
@@ -84,9 +84,9 @@
 | INV-03 | Phase 2 | Complete |
 | INV-04 | Phase 2 | Complete |
 | DOT-01 | Phase 3 | Pending |
-| DOT-02 | Phase 3 | Pending |
+| DOT-02 | Phase 3 | Complete |
 | DOT-03 | Phase 3 | Pending |
-| DOT-04 | Phase 3 | Pending |
+| DOT-04 | Phase 3 | Complete |
 | PROV-01 | Phase 4 | Pending |
 | PROV-02 | Phase 4 | Pending |
 | PROV-03 | Phase 4 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -13,7 +13,7 @@ This roadmap turns tilde from a setup wizard into a machine-aware setup assistan
 
 - [x] **Phase 1: Tool Metadata Registry** - Create the shared data model and registry lookup layer for wizard tool metadata. (completed 2026-06-13)
 - [x] **Phase 2: Machine Inventory Scanner** - Detect installed tools and Homebrew direct-vs-dependency provenance. (completed 2026-06-13)
-- [ ] **Phase 3: Dotfiles Discovery Map** - Map known dotfiles and rc-file contents to tools.
+- [x] **Phase 3: Dotfiles Discovery Map** - Map known dotfiles and rc-file contents to tools. (completed 2026-06-19)
 - [ ] **Phase 4: Provenance Summary** - Surface clear managed/already-installed/dependency/manual/unknown status to users.
 - [ ] **Phase 5: Config Discovery Polish** - Improve non-default config discovery and error messaging.
 
@@ -106,11 +106,11 @@ Plans:
 
 **Wave 1**
 
-- [ ] 03-01-PLAN.md - Add metadata-driven dotfile path discovery.
+- [x] 03-01-PLAN.md - Add metadata-driven dotfile path discovery.
 
 **Wave 2 (blocked on Wave 1 completion)**
 
-- [ ] 03-02-PLAN.md - Add rc-file parsing and structured dotfile map output.
+- [x] 03-02-PLAN.md - Add rc-file parsing and structured dotfile map output.
 
 ### Phase 4: Provenance Summary
 
@@ -161,6 +161,6 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
 |-------|----------------|--------|-----------|
 | 1. Tool Metadata Registry | 3/3 | Complete    | 2026-06-13 |
 | 2. Machine Inventory Scanner | 7/7 | Complete   | 2026-06-14 |
-| 3. Dotfiles Discovery Map | 0/2 | Not started | - |
+| 3. Dotfiles Discovery Map | 2/2 | Complete   | 2026-06-19 |
 | 4. Provenance Summary | 0/2 | Not started | - |
 | 5. Config Discovery Polish | 0/1 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -161,6 +161,6 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
 |-------|----------------|--------|-----------|
 | 1. Tool Metadata Registry | 3/3 | Complete    | 2026-06-13 |
 | 2. Machine Inventory Scanner | 7/7 | Complete   | 2026-06-14 |
-| 3. Dotfiles Discovery Map | 2/2 | Complete   | 2026-06-19 |
+| 3. Dotfiles Discovery Map | 2/2 | Complete    | 2026-06-19 |
 | 4. Provenance Summary | 0/2 | Not started | - |
 | 5. Config Discovery Polish | 0/1 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -104,8 +104,13 @@ Plans:
 
 Plans:
 
-- [ ] 03-01: Add metadata-driven dotfile path discovery.
-- [ ] 03-02: Add rc-file parsing and structured dotfile map output.
+**Wave 1**
+
+- [ ] 03-01-PLAN.md - Add metadata-driven dotfile path discovery.
+
+**Wave 2 (blocked on Wave 1 completion)**
+
+- [ ] 03-02-PLAN.md - Add rc-file parsing and structured dotfile map output.
 
 ### Phase 4: Provenance Summary
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Completed 02-06-PLAN.md
-last_updated: "2026-06-14T00:58:49.242Z"
+stopped_at: Phase 3 context gathered
+last_updated: "2026-06-19T01:01:59.552Z"
 last_activity: 2026-06-13 -- Phase 02 execution started
 progress:
   total_phases: 5
@@ -97,6 +97,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-14T00:58:49.239Z
-Stopped at: Completed 02-06-PLAN.md
-Resume file: None
+Last session: 2026-06-19T01:01:59.549Z
+Stopped at: Phase 3 context gathered
+Resume file: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 3 context gathered
-last_updated: "2026-06-19T01:59:33.137Z"
-last_activity: 2026-06-13 -- Phase 02 execution started
+stopped_at: Completed 03-02-PLAN.md
+last_updated: "2026-06-19T22:37:01.155Z"
+last_activity: 2026-06-19 -- Phase 03 plan 02 completed
 progress:
   total_phases: 5
-  completed_phases: 2
-  total_plans: 10
-  completed_plans: 10
-  percent: 40
+  completed_phases: 3
+  total_plans: 12
+  completed_plans: 12
+  percent: 60
 ---
 
 # Project State
@@ -21,22 +21,22 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-12)
 
 **Core value:** tilde should explain a machine's developer setup clearly enough that users can trust what it will manage before it changes anything.
-**Current focus:** Phase 02 — machine-inventory-scanner
+**Current focus:** Phase 03 — dotfiles-discovery-map
 
 ## Current Position
 
-Phase: 02 (machine-inventory-scanner) — EXECUTING
-Plan: 2 of 7
-Status: Ready to execute
-Last activity: 2026-06-13 -- Phase 02 execution started
+Phase: 03 (dotfiles-discovery-map) — COMPLETE
+Plan: 2 of 2
+Status: Ready for next phase
+Last activity: 2026-06-19 -- Phase 03 plan 02 completed
 
-Progress: [██████████] 100%
+Progress: [██████░░░░] 60%
 
 ## Performance Metrics
 
 **Velocity:**
 
-- Total plans completed: 3
+- Total plans completed: 12
 - Average duration: 17 min
 - Total execution time: 50 min
 
@@ -57,6 +57,7 @@ Progress: [██████████] 100%
 | Phase 02 P04 | 14min | 2 tasks | 8 files |
 | Phase 02 P05 | 9min | 2 tasks | 6 files |
 | Phase 02 P06 | 36min | 3 tasks | 7 files |
+| Phase 03 P02 | 17min | 2 tasks | 5 files |
 
 ## Accumulated Context
 
@@ -78,6 +79,9 @@ Recent decisions affecting current work:
 - [Phase 02]: Inventory warning grouping is centralized in summarizeInventory so wizard and config-first output cannot drift.
 - [Phase 02]: Use InventoryScanState as the shared readiness contract for startup inventory. — This lets App distinguish pending scans from completed empty reports before wizard or config-first actions are shown.
 - [Phase 02]: Installed inventory facts stay out of ToolsStep.defaultTools. — Inventory facts are evidence for trust summaries and must not become generic package-manager install requests without explicit mapping.
+- [Phase ?]: Rc parser output stores env names and value kinds only; raw values, command substitutions, and function bodies are not persisted.
+- [Phase ?]: Wizard and config-first output share the new Dotfile findings line from summarizeInventory().
+- [Phase ?]: Known rc hooks count as known tool findings while aliases, functions, exports, PATH edits, and source statements remain unknown rc evidence.
 
 ### Pending Todos
 
@@ -97,6 +101,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-19T01:01:59.549Z
-Stopped at: Phase 3 context gathered
-Resume file: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+Last session: 2026-06-19T22:18:16.820Z
+Stopped at: Completed 03-02-PLAN.md
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v1.0
 milestone_name: milestone
 status: executing
 stopped_at: Phase 3 context gathered
-last_updated: "2026-06-19T01:01:59.552Z"
+last_updated: "2026-06-19T01:59:33.137Z"
 last_activity: 2026-06-13 -- Phase 02 execution started
 progress:
   total_phases: 5

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: executing
+status: Ready for next phase
 stopped_at: Completed 03-02-PLAN.md
-last_updated: "2026-06-19T22:37:01.155Z"
-last_activity: 2026-06-19 -- Phase 03 plan 02 completed
+last_updated: "2026-06-19T22:56:18.841Z"
+last_activity: 2026-06-19
 progress:
   total_phases: 5
   completed_phases: 3
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-06-12)
 
 ## Current Position
 
-Phase: 03 (dotfiles-discovery-map) — COMPLETE
-Plan: 2 of 2
+Phase: 4
+Plan: Not started
 Status: Ready for next phase
-Last activity: 2026-06-19 -- Phase 03 plan 02 completed
+Last activity: 2026-06-19
 
 Progress: [██████░░░░] 60%
 
@@ -36,7 +36,7 @@ Progress: [██████░░░░] 60%
 
 **Velocity:**
 
-- Total plans completed: 12
+- Total plans completed: 14
 - Average duration: 17 min
 - Total execution time: 50 min
 
@@ -45,6 +45,7 @@ Progress: [██████░░░░] 60%
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
 | 01 | 3 | 50 min | 17 min |
+| 03 | 2 | - | - |
 
 **Recent Trend:**
 

--- a/.planning/phases/03-dotfiles-discovery-map/03-01-PLAN.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-01-PLAN.md
@@ -1,0 +1,267 @@
+---
+phase: 03-dotfiles-discovery-map
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/inventory/dotfiles.ts
+  - src/inventory/report.ts
+  - src/inventory/scan.ts
+  - src/inventory/summary.ts
+  - tests/unit/inventory-dotfiles.test.ts
+  - tests/unit/inventory-scanner.test.ts
+autonomous: true
+requirements: [DOT-01, DOT-03, DOT-04]
+user_setup: []
+must_haves:
+  truths:
+    - "User can see a concise inventory summary that includes known and unknown dotfile counts."
+    - "Known metadata-declared config and dotfile paths are mapped to tool ids without final provenance labels."
+    - "Home, dotfiles repo, and workspace candidates are scanned read-only through bounded allowlists."
+    - "Unknown files are represented as normal dotfile evidence, not report errors."
+  artifacts:
+    - path: "src/inventory/dotfiles.ts"
+      provides: "Dotfile candidate discovery, metadata path matching, safe scan orchestration, and empty map defaults"
+      exports: ["createEmptyDotfileMap", "scanDotfileMap"]
+    - path: "src/inventory/report.ts"
+      provides: "InventoryReport dotfiles section and dotfile warning source"
+      contains: "dotfiles"
+    - path: "src/inventory/scan.ts"
+      provides: "scanInventory integration for dotfile map discovery"
+      contains: "scanDotfileMap"
+    - path: "src/inventory/summary.ts"
+      provides: "Concise dotfile count summary"
+      contains: "Dotfiles:"
+    - path: "tests/unit/inventory-dotfiles.test.ts"
+      provides: "DOT-01, DOT-03, and DOT-04 unit coverage"
+      min_lines: 120
+  key_links:
+    - from: "src/inventory/scan.ts"
+      to: "src/inventory/dotfiles.ts"
+      via: "scanDotfileMap call in scanInventory"
+      pattern: "scanDotfileMap"
+    - from: "src/inventory/dotfiles.ts"
+      to: "src/tools/registry.ts"
+      via: "getToolsByConfigPath/getToolsByDotfilePath"
+      pattern: "getToolsBy(Config|Dotfile)Path"
+    - from: "src/inventory/summary.ts"
+      to: "InventoryReport.dotfiles"
+      via: "summary counts"
+      pattern: "report\\.dotfiles"
+---
+
+## Phase Goal
+
+**As a** tilde user, **I want to** see which known dotfiles and config paths map to tools, **so that** I can trust what tilde understands before it changes anything.
+
+<objective>
+Create the first vertical slice of the dotfiles discovery map: read-only path discovery, metadata-backed known-tool matching, unknown-file separation, and concise inventory summary output.
+
+Purpose: Satisfy DOT-01, DOT-03, and the path-level portion of DOT-04 while implementing D-01 through D-04 and D-09 through D-15 without assigning Phase 4 provenance labels.
+Output: A top-level `InventoryReport.dotfiles` map, `src/inventory/dotfiles.ts`, scanner integration, concise summary lines, and unit coverage.
+</objective>
+
+<execution_context>
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/workflows/execute-plan.md
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+@.planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+@.planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
+@.planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+@.planning/phases/02-machine-inventory-scanner/02-CONTEXT.md
+@.planning/phases/02-machine-inventory-scanner/02-01-SUMMARY.md
+@.planning/phases/02-machine-inventory-scanner/02-03-SUMMARY.md
+@.planning/phases/02-machine-inventory-scanner/02-05-SUMMARY.md
+@.planning/phases/02-machine-inventory-scanner/02-06-SUMMARY.md
+@src/inventory/report.ts
+@src/inventory/scan.ts
+@src/inventory/summary.ts
+@src/tools/registry.ts
+@src/tools/metadata.ts
+@src/capture/scanner.ts
+@src/capture/filter.ts
+@src/config/schema.ts
+@tests/unit/inventory-scanner.test.ts
+@tests/unit/tool-metadata.test.ts
+</context>
+
+## Artifacts This Phase Produces
+
+New file paths:
+- `src/inventory/dotfiles.ts`
+- `tests/unit/inventory-dotfiles.test.ts`
+
+New exported functions and types:
+- `createEmptyDotfileMap(homeDir?: string)`
+- `scanDotfileMap(options: DotfileScanOptions)`
+- `parseShellRcFindings(filePath: string, content: string)`
+- `classifyRcExportValue(rawValue: string)`
+- `DotfileScanOptions`
+- `DotfileScanScope`
+- `DotfileFindingKind`
+- `DotfileFindingClassification`
+- `DotfileFinding`
+- `DotfileFileSummary`
+- `DotfileToolSummary`
+- `DotfileMap`
+
+New or extended type fields:
+- `InventoryReport.dotfiles`
+- `InventoryWarningSource` includes `'dotfiles'`
+- `InventoryScanOptions.dotfilesRepo`
+- `InventoryScanOptions.workspaceRoots`
+
+New CLI flags:
+- None.
+
+<source_audit>
+| SOURCE | ID | Feature/Requirement | Plan | Status | Notes |
+|--------|----|---------------------|------|--------|-------|
+| GOAL | -- | Map known dotfiles and shell rc-file contents to tools | 03-01, 03-02 | COVERED | This plan covers path mapping; 03-02 covers rc contents. |
+| REQ | DOT-01 | Map known dotfile paths to related tools using registry metadata | 03-01 | COVERED | Uses `getToolsByConfigPath()` and `getToolsByDotfilePath()`. |
+| REQ | DOT-02 | Parse common shell rc files for aliases, env vars, plugin references, PATH edits | 03-02 | COVERED | Planned in Wave 2. |
+| REQ | DOT-03 | Look for tool config files in home and workspace context locations without mutating them | 03-01 | COVERED | Adds bounded candidates for home, dotfiles repo, and workspace roots. |
+| REQ | DOT-04 | Identify unknown files separately from known tool-owned files | 03-01, 03-02 | COVERED | This plan covers unknown files; 03-02 covers unknown rc findings. |
+| RESEARCH | -- | Add top-level dotfile map to `InventoryReport` | 03-01 | COVERED | `InventoryReport.dotfiles` is required. |
+| RESEARCH | -- | Keep scanner logic out of Ink components | 03-01 | COVERED | Only `scanInventory()` and pure summary helpers change. |
+| RESEARCH | -- | Avoid new package installs | 03-01 | COVERED | Uses existing Node fs, `fast-glob`, `ignore`, and registry helpers. |
+| RESEARCH | -- | Mitigate secret disclosure, symlink traversal, parse blocking, and shell execution | 03-01, 03-02 | COVERED | Threat model below and task acceptance criteria require mitigations. |
+| CONTEXT | D-01 | Hybrid evidence-first findings plus derived tool summaries | 03-01 | COVERED | `DotfileMap.files` plus `DotfileMap.tools`. |
+| CONTEXT | D-02 | Preserve path, scan scope, matched tool id, reason/confidence, type, safe details | 03-01 | COVERED | `DotfileFinding` and file summary fields are required. |
+| CONTEXT | D-03 | Support mixed known/unknown file summaries with nested findings | 03-01 | COVERED | File state must include `known`, `unknown`, `mixed`, and `skipped`. |
+| CONTEXT | D-04 | Unknown files/findings reported separately and not as errors | 03-01, 03-02 | COVERED | Unknown files are counted and findings are nested evidence. |
+| CONTEXT | D-05 | Parse core rc constructs | 03-02 | COVERED | Planned in Wave 2. |
+| CONTEXT | D-06 | Do not deeply interpret shell or model arbitrary script execution | 03-02 | COVERED | Planned parser is line-oriented and text-only. |
+| CONTEXT | D-07 | Record env names and value kinds only | 03-02 | COVERED | Planned in Wave 2. |
+| CONTEXT | D-08 | Do not persist secret-looking values | 03-02 | COVERED | Planned in Wave 2. |
+| CONTEXT | D-09 | Combined bounded read-only scan for home rc, metadata paths, dotfiles repo, workspace roots | 03-01 | COVERED | Candidate scopes must include those inputs where configured. |
+| CONTEXT | D-10 | Workspace scan limited to root files and shallow allowlisted directories | 03-01 | COVERED | Task requires explicit allowlists and low depth. |
+| CONTEXT | D-11 | Deterministic traversal; no broad recursive crawling | 03-01 | COVERED | Task acceptance rejects broad recursive globs. |
+| CONTEXT | D-12 | Missing/unreadable paths and parse failures produce warnings/skips | 03-01, 03-02 | COVERED | Path failures are warnings/skipped files; parse failures handled in 03-02. |
+| CONTEXT | D-13 | Expose concise summary in existing inventory step | 03-01 | COVERED | `summarizeInventory()` gets dotfile count lines. |
+| CONTEXT | D-14 | Default terminal output stays small; detailed audit data stays structured | 03-01 | COVERED | Summary uses counts/labels only. |
+| CONTEXT | D-15 | Reuse `summarizeInventory`/inventory-step pattern | 03-01 | COVERED | No separate UI text path. |
+</source_audit>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing dotfile path discovery tests</name>
+  <read_first>
+    .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+    .planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+    .planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
+    .planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+    src/inventory/report.ts
+    src/inventory/scan.ts
+    src/inventory/summary.ts
+    src/tools/registry.ts
+    src/capture/scanner.ts
+    src/capture/filter.ts
+    tests/unit/inventory-scanner.test.ts
+    tests/unit/inventory-dotfiles.test.ts (create)
+  </read_first>
+  <files>tests/unit/inventory-dotfiles.test.ts, tests/unit/inventory-scanner.test.ts</files>
+  <behavior>
+    - Test DOT-01/D-01/D-02: `scanDotfileMap()` maps existing metadata-declared `~/.config/nvim` and `~/.obsidian` paths to `neovim` and `obsidian` tool ids with path, scope, reason, finding kind, classification, and safe details.
+    - Test DOT-03/D-09/D-10/D-11: home, configured dotfiles repo, and workspace-root candidates are discovered through explicit root/shallow allowlists, and a nested non-allowlisted file is absent from the map.
+    - Test DOT-04/D-03/D-04/D-12: unknown files are counted and represented separately from known tool-owned files, missing candidates do not warn, and unreadable or symlink-skipped candidates produce dotfile warnings without rejecting the scan.
+    - Test D-13/D-14/D-15: `summarizeInventory()` includes one concise `Dotfiles:` line and does not print detailed unknown file paths.
+  </behavior>
+  <action>Add RED Vitest coverage for the path-discovery slice. Create `tests/unit/inventory-dotfiles.test.ts` with temp-directory fixtures using `mkdir`, `writeFile`, `rm`, `tmpdir`, and `randomUUID`, following `tests/unit/capture-scanner.test.ts`. Extend `tests/unit/inventory-scanner.test.ts` to assert `scanInventory(tmpHome)` attaches `report.dotfiles` and that `summarizeInventory(report)` includes aggregate dotfile counts. Use mocked registry metadata only where the scanner test already mocks `../../src/tools/registry.js`; keep the new dotfile unit test against real registry helpers for confirmed existing metadata. Do not use real external commands, do not add package installs, and do not use Vitest `-x`.</action>
+  <verify>
+    <automated>npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - The targeted command fails before implementation because `src/inventory/dotfiles.ts`, `InventoryReport.dotfiles`, or `scanDotfileMap` does not exist yet.
+    - Tests assert known metadata paths by tool id, unknown file separation, bounded workspace scan behavior, warning/skipped behavior, and concise summary output.
+    - Tests contain no raw secret values expected in scanner output and no assertions that final provenance labels exist.
+  </acceptance_criteria>
+  <done>RED coverage exists for DOT-01, DOT-03, and path-level DOT-04, with explicit D-01/D-02/D-03/D-04/D-09/D-10/D-11/D-12/D-13/D-14/D-15 expectations.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement metadata-driven dotfile map and inventory summary</name>
+  <read_first>
+    .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+    .planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+    .planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+    src/inventory/report.ts
+    src/inventory/scan.ts
+    src/inventory/summary.ts
+    src/tools/registry.ts
+    src/capture/filter.ts
+    src/config/schema.ts
+    tests/unit/inventory-dotfiles.test.ts
+    tests/unit/inventory-scanner.test.ts
+  </read_first>
+  <files>src/inventory/dotfiles.ts, src/inventory/report.ts, src/inventory/scan.ts, src/inventory/summary.ts, tests/unit/inventory-dotfiles.test.ts, tests/unit/inventory-scanner.test.ts</files>
+  <behavior>
+    - `scanDotfileMap()` returns an evidence-first `DotfileMap` with file summaries, nested findings, derived tool summaries, counts, and warning ids.
+    - `scanInventory()` populates `InventoryReport.dotfiles` while preserving all existing Homebrew, environment, shell, and readiness behavior.
+    - `summarizeInventory()` adds concise dotfile count/group output before warnings and never dumps detailed file paths by default.
+  </behavior>
+  <action>Create `src/inventory/dotfiles.ts` and export `createEmptyDotfileMap()` plus `scanDotfileMap(options: DotfileScanOptions)`. Define dotfile map types in this module and import the map type into `src/inventory/report.ts` so `InventoryReport` has a top-level `dotfiles` field. Extend `InventoryWarningSource` with `'dotfiles'`. Add an `InventoryScanOptions` type in `src/inventory/scan.ts` with optional `dotfilesRepo` and `workspaceRoots`, update `scanInventory(homeDir?, options?)`, and call `scanDotfileMap({ homeDir: resolvedHome, dotfilesRepo: options?.dotfilesRepo, workspaceRoots: options?.workspaceRoots, warnings })`. Generate candidates from metadata-declared `configPaths` and `dotfilePaths`, home dotfiles filtered through `createCaptureFilter()`/`filterDotfiles()`, configured dotfiles repo root/shallow files, and workspace roots using explicit allowlists. Use `getToolsByConfigPath()` and `getToolsByDotfilePath()` for known matching; do not reimplement per-tool switch logic. Keep all filesystem work read-only, use low-depth `fast-glob` patterns with `onlyFiles`, `dot`, and `followSymbolicLinks: false`, skip symlinks or unreadable candidates with dotfile warnings, treat missing candidates as absent, and do not scan `node_modules`, `.git`, `.env`, `.env.*`, key files, logs, or unallowlisted descendants. Update `createEmptyInventoryReport()` and `summarizeInventory()` for deterministic empty and summary behavior. Do not add final provenance labels, a new command, or UI-specific scanner logic.</action>
+  <verify>
+    <automated>npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts</automated>
+    <automated>npm run build</automated>
+    <automated>npm run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - `InventoryReport.dotfiles` exists on every report, including `createEmptyInventoryReport()`.
+    - Known path findings preserve path, scan scope, matched tool ids, match reason/confidence, finding type, classification, and safe details per D-01/D-02.
+    - File summaries can be `known`, `unknown`, `mixed`, or `skipped` per D-03, and unknown files are counted without becoming errors per D-04.
+    - Workspace scans use explicit root files and shallow allowlisted directories only, with no broad recursive traversal per D-10/D-11.
+    - The summary line is concise and shared through `summarizeInventory()` per D-13/D-14/D-15.
+  </acceptance_criteria>
+  <done>DOT-01 and DOT-03 pass with metadata-driven path mapping, bounded read-only scan scopes, structured unknown-file evidence, and concise inventory summary output.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| local filesystem -> dotfile scanner | User-controlled file names, symlinks, permissions, and file contents enter inventory code. |
+| registry metadata -> path matcher | Static metadata path strings are used to identify known tool-owned paths. |
+| dotfile map -> terminal summary | Structured evidence is compressed into user-visible Ink/config-first output. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-03-01 | Information Disclosure | `src/inventory/dotfiles.ts` file candidate scanning | mitigate | Reuse `createCaptureFilter()` and default secret patterns; exclude `.env`, `.env.*`, key files, logs, `node_modules`, and `.git`; summary output must not print detailed paths by default. |
+| T-03-02 | Information Disclosure | workspace and dotfiles repo traversal | mitigate | Use explicit candidates, shallow allowlisted directories, low depth, `followSymbolicLinks: false`, and skipped/warning findings for symlinks or unreadable files. |
+| T-03-03 | Denial of Service | missing or unreadable local paths | mitigate | Treat missing candidates as absent and unexpected read/stat failures as `source: 'dotfiles'` warnings without rejecting `scanInventory()`. |
+| T-03-04 | Tampering | registry path matching | mitigate | Use existing validated metadata and registry helpers rather than accepting arbitrary per-tool path rules from scanned files. |
+| T-03-SC | Tampering | npm installs | mitigate | No package-manager install tasks are allowed in this plan; existing locked dependencies only. |
+</threat_model>
+
+<verification>
+Run after both tasks:
+- `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts`
+- `npm run build`
+- `npm run lint`
+</verification>
+
+<success_criteria>
+- `scanDotfileMap()` maps known metadata config/dotfile paths to tool ids.
+- `scanInventory()` always returns `InventoryReport.dotfiles`.
+- Home, dotfiles repo, and workspace candidates are discovered only through bounded read-only allowlists.
+- Unknown files are separate evidence and not errors.
+- Inventory summary includes concise dotfile counts without detailed path dumps.
+</success_criteria>
+
+<output>
+Create `.planning/phases/03-dotfiles-discovery-map/03-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/03-dotfiles-discovery-map/03-01-SUMMARY.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-01-SUMMARY.md
@@ -1,0 +1,110 @@
+---
+phase: 03-dotfiles-discovery-map
+plan: 01
+subsystem: inventory
+tags: [dotfiles, inventory, metadata, scanner, vitest]
+requires:
+  - phase: 02-machine-inventory-scanner
+    provides: InventoryReport, scanInventory, summarizeInventory, and tool metadata registry integration
+provides:
+  - Evidence-first DotfileMap with known, unknown, mixed, and skipped file summaries
+  - Read-only dotfile candidate discovery for home, dotfiles repo, and workspace roots
+  - Metadata-backed config path and dotfile path matching
+  - Concise inventory summary counts for known, unknown, and warning dotfiles
+affects: [inventory, dotfiles, wizard-summary, config-first-summary]
+tech-stack:
+  added: []
+  patterns: [read-only bounded filesystem scanning, evidence-first inventory summaries]
+key-files:
+  created: [src/inventory/dotfiles.ts, tests/unit/inventory-dotfiles.test.ts]
+  modified: [src/inventory/report.ts, src/inventory/scan.ts, src/inventory/summary.ts, tests/unit/inventory-scanner.test.ts]
+key-decisions:
+  - "Dotfile findings are evidence records with tool ids and safe details, not final provenance labels."
+  - "Unknown dotfiles are normal inventory evidence and are counted separately from warnings."
+patterns-established:
+  - "Dotfile scanning uses bounded candidate generation with missing paths treated as absent."
+  - "Inventory summaries expose aggregate dotfile counts without printing detailed paths."
+requirements-completed: [DOT-01, DOT-03, DOT-04]
+duration: 56min
+completed: 2026-06-19
+---
+
+# Phase 03: Dotfiles Discovery Map Plan 01 Summary
+
+**Read-only dotfile path discovery map with metadata-backed known-tool matching and concise inventory counts**
+
+## Performance
+
+- **Duration:** 56 min
+- **Started:** 2026-06-19T02:02:00Z
+- **Completed:** 2026-06-19T17:58:30Z
+- **Tasks:** 2
+- **Files modified:** 6
+
+## Accomplishments
+
+- Added `src/inventory/dotfiles.ts` with `DotfileMap`, file findings, derived tool summaries, empty defaults, and scanner entry points.
+- Integrated dotfile scanning into `InventoryReport`, `scanInventory()`, and `summarizeInventory()`.
+- Added unit coverage for metadata path matching, unknown-file separation, bounded workspace scanning, skipped symlinks, scanner integration, and concise summary output.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add failing dotfile path discovery tests** - `81f6086` (test)
+2. **Task 2: Implement metadata-driven dotfile map and inventory summary** - `45f28a5` (feat)
+
+**Plan metadata:** this summary commit
+
+## Files Created/Modified
+
+- `src/inventory/dotfiles.ts` - Dotfile scan types, empty map creation, bounded candidate discovery, metadata matching, warnings, and rc parser helpers.
+- `src/inventory/report.ts` - Adds `InventoryReport.dotfiles` and the `dotfiles` warning source.
+- `src/inventory/scan.ts` - Adds `InventoryScanOptions` and populates `report.dotfiles`.
+- `src/inventory/summary.ts` - Adds the concise `Dotfiles:` aggregate summary line.
+- `tests/unit/inventory-dotfiles.test.ts` - Covers DOT-01, DOT-03, and path-level DOT-04 behavior.
+- `tests/unit/inventory-scanner.test.ts` - Covers scanner integration and summary output.
+
+## Decisions Made
+
+- Unknown files remain normal `DotfileFinding` evidence with `classification: 'unknown'`; they are not report errors.
+- Missing candidates are ignored, while symlink and unreadable candidates become skipped file summaries with dotfile warnings.
+- Summary output reports only counts so default terminal output stays concise.
+
+## Deviations from Plan
+
+None - plan executed as written.
+
+---
+
+**Total deviations:** 0 auto-fixed.
+**Impact on plan:** No scope change.
+
+## Issues Encountered
+
+- The spawned executor stalled after the RED commit. The orchestrator closed it, preserved the RED commit, and finished the GREEN implementation inline from the visible working tree state.
+
+## Verification
+
+- `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` - passed, 2 files and 12 tests.
+- `npm run build` - passed.
+- `npm run lint` - passed.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+Wave 2 can build rc-file content parsing on top of the committed dotfile path map and scanner integration.
+
+## Self-Check: PASSED
+
+- Key created files exist.
+- Task commits exist for `03-01`.
+- Verification commands passed.
+- No final provenance labels were added.
+
+---
+*Phase: 03-dotfiles-discovery-map*
+*Completed: 2026-06-19*

--- a/.planning/phases/03-dotfiles-discovery-map/03-02-PLAN.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-02-PLAN.md
@@ -1,0 +1,244 @@
+---
+phase: 03-dotfiles-discovery-map
+plan: 02
+type: execute
+wave: 2
+depends_on: [03-01]
+files_modified:
+  - src/inventory/dotfiles.ts
+  - src/inventory/summary.ts
+  - tests/unit/inventory-dotfiles.test.ts
+  - tests/integration/wizard-flow.test.tsx
+  - tests/integration/config-first.test.ts
+autonomous: true
+requirements: [DOT-02, DOT-04]
+user_setup: []
+must_haves:
+  truths:
+    - "User can see concise inventory output that accounts for rc-file findings without exposing raw values."
+    - "Aliases, function names, export names/value kinds, PATH edits, source statements, and known init hooks are represented as structured findings."
+    - "Unknown rc-file findings are separate from known tool-hook findings and are not treated as errors."
+    - "Wizard and config-first surfaces share the same dotfile summary text."
+  artifacts:
+    - path: "src/inventory/dotfiles.ts"
+      provides: "Safe shell rc parser and rc finding integration"
+      exports: ["parseShellRcFindings", "classifyRcExportValue"]
+    - path: "src/inventory/summary.ts"
+      provides: "Concise rc-aware dotfile summary"
+      contains: "Dotfile findings:"
+    - path: "tests/unit/inventory-dotfiles.test.ts"
+      provides: "DOT-02 and rc-level DOT-04 coverage"
+      min_lines: 220
+    - path: "tests/integration/wizard-flow.test.tsx"
+      provides: "Wizard dotfile summary regression"
+      contains: "Dotfiles:"
+    - path: "tests/integration/config-first.test.ts"
+      provides: "Config-first dotfile summary regression"
+      contains: "Dotfiles:"
+  key_links:
+    - from: "src/inventory/dotfiles.ts"
+      to: "src/inventory/summary.ts"
+      via: "DotfileMap rc finding counts"
+      pattern: "unknownFindingsCount"
+    - from: "tests/integration/wizard-flow.test.tsx"
+      to: "src/inventory/summary.ts"
+      via: "shared summarizeInventory output"
+      pattern: "Dotfiles:"
+    - from: "tests/integration/config-first.test.ts"
+      to: "src/inventory/summary.ts"
+      via: "shared summarizeInventory output"
+      pattern: "Dotfiles:"
+---
+
+## Phase Goal
+
+**As a** tilde user, **I want to** see which shell rc-file contents map to known tools, **so that** I can distinguish trusted setup evidence from unknown local customization before tilde changes anything.
+
+<objective>
+Add the rc-file parsing slice on top of the dotfile path map from Plan 03-01: parse safe shell constructs, classify known tool hooks and unknown findings, protect environment values, and prove shared wizard/config-first output.
+
+Purpose: Satisfy DOT-02 and finish DOT-04 while implementing D-04 through D-08 and D-12 through D-15.
+Output: Rc parser functions, rc findings integrated into `DotfileMap`, rc-aware concise summary output, and unit/integration coverage.
+</objective>
+
+<execution_context>
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/workflows/execute-plan.md
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+@.planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+@.planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
+@.planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+@.planning/phases/03-dotfiles-discovery-map/03-01-SUMMARY.md
+@src/inventory/dotfiles.ts
+@src/inventory/report.ts
+@src/inventory/summary.ts
+@src/capture/parser.ts
+@src/dotfiles/shellprofile.ts
+@src/plugins/first-party/direnv/index.ts
+@src/plugins/first-party/vfox/index.ts
+@src/plugins/first-party/onepassword/index.ts
+@tests/unit/inventory-dotfiles.test.ts
+@tests/integration/wizard-flow.test.tsx
+@tests/integration/config-first.test.ts
+</context>
+
+## Artifacts This Phase Produces
+
+New file paths:
+- `src/inventory/dotfiles.ts`
+- `tests/unit/inventory-dotfiles.test.ts`
+
+New exported functions and types:
+- `createEmptyDotfileMap(homeDir?: string)`
+- `scanDotfileMap(options: DotfileScanOptions)`
+- `parseShellRcFindings(filePath: string, content: string)`
+- `classifyRcExportValue(rawValue: string)`
+- `DotfileScanOptions`
+- `DotfileScanScope`
+- `DotfileFindingKind`
+- `DotfileFindingClassification`
+- `DotfileFinding`
+- `DotfileFileSummary`
+- `DotfileToolSummary`
+- `DotfileMap`
+
+New or extended type fields:
+- `InventoryReport.dotfiles`
+- `InventoryWarningSource` includes `'dotfiles'`
+- `InventoryScanOptions.dotfilesRepo`
+- `InventoryScanOptions.workspaceRoots`
+
+New CLI flags:
+- None.
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing rc parsing and shared-output tests</name>
+  <read_first>
+    .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+    .planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+    .planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
+    .planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+    .planning/phases/03-dotfiles-discovery-map/03-01-SUMMARY.md
+    src/inventory/dotfiles.ts
+    src/inventory/summary.ts
+    src/capture/parser.ts
+    src/dotfiles/shellprofile.ts
+    src/plugins/first-party/direnv/index.ts
+    src/plugins/first-party/vfox/index.ts
+    src/plugins/first-party/onepassword/index.ts
+    tests/unit/inventory-dotfiles.test.ts
+    tests/integration/wizard-flow.test.tsx
+    tests/integration/config-first.test.ts
+  </read_first>
+  <files>tests/unit/inventory-dotfiles.test.ts, tests/integration/wizard-flow.test.tsx, tests/integration/config-first.test.ts</files>
+  <behavior>
+    - Test DOT-02/D-05: rc parsing emits alias names, function names, export names/value kinds, PATH edits, source statements, and known init hooks.
+    - Test D-06: parser does not execute or model shell commands, full function bodies, arbitrary conditions, or broad control flow.
+    - Test D-07/D-08: exports store names and value kinds only; JSON output does not contain raw literal values, command substitutions, `op://` references, token-looking values, or secret-looking values.
+    - Test DOT-04/D-04: unknown aliases/functions/sources are counted separately from known `direnv`, `vfox`, `1password`, and `homebrew` hook findings.
+    - Test D-13/D-14/D-15: wizard and config-first inventory blocks show the shared dotfile summary line and do not dump individual rc lines or detailed unknown paths.
+  </behavior>
+  <action>Extend `tests/unit/inventory-dotfiles.test.ts` with RED coverage for `parseShellRcFindings()` and rc integration through `scanDotfileMap()`. Use representative rc text containing `alias gs=...`, a simple `function workon() { ... }`, `export EDITOR=nvim`, `export PATH="$HOME/bin:$PATH"`, `export GH_TOKEN=ghp_secret`, `export OP_REF=op://Personal/item/field`, `export GENERATED="$(tool command)"`, `source ~/.aliases`, `eval "$(direnv hook zsh)"`, `eval "$(vfox activate zsh)"`, `eval "$(op signin)"`, and `eval "$(/opt/homebrew/bin/brew shellenv)"`. Extend `tests/integration/wizard-flow.test.tsx` and `tests/integration/config-first.test.ts` fixture reports to include `dotfiles` with known and unknown rc findings, then assert the inventory block contains concise `Dotfiles:` or `Dotfile findings:` text and omits raw rc values, source line bodies, and unknown detailed paths. Do not add a separate command or duplicate summary wording outside `summarizeInventory()`.</action>
+  <verify>
+    <automated>npm run test -- tests/unit/inventory-dotfiles.test.ts</automated>
+    <automated>npm run test:integration -- tests/integration/wizard-flow.test.tsx tests/integration/config-first.test.ts -t inventory</automated>
+  </verify>
+  <acceptance_criteria>
+    - Unit tests fail before implementation because `parseShellRcFindings()` or rc finding kinds are missing.
+    - Tests prove env raw values are absent by serializing findings and checking the serialized string does not contain secret-like or literal rc values.
+    - Integration tests prove both wizard and config-first consume the same aggregate summary and keep detailed audit data out of default output.
+  </acceptance_criteria>
+  <done>RED coverage exists for DOT-02 and rc-level DOT-04, including D-05/D-06/D-07/D-08/D-13/D-14/D-15 behavior.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement safe rc findings and rc-aware summaries</name>
+  <read_first>
+    .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+    .planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+    .planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+    .planning/phases/03-dotfiles-discovery-map/03-01-SUMMARY.md
+    src/inventory/dotfiles.ts
+    src/inventory/summary.ts
+    src/capture/parser.ts
+    src/dotfiles/shellprofile.ts
+    src/plugins/first-party/direnv/index.ts
+    src/plugins/first-party/vfox/index.ts
+    src/plugins/first-party/onepassword/index.ts
+    tests/unit/inventory-dotfiles.test.ts
+    tests/integration/wizard-flow.test.tsx
+    tests/integration/config-first.test.ts
+  </read_first>
+  <files>src/inventory/dotfiles.ts, src/inventory/summary.ts, tests/unit/inventory-dotfiles.test.ts, tests/integration/wizard-flow.test.tsx, tests/integration/config-first.test.ts</files>
+  <behavior>
+    - Rc files contribute nested `alias`, `function`, `export`, `path-edit`, `source`, and `tool-init-hook` findings to their file summaries.
+    - Known tool hooks map to existing tool ids where known: `direnv`, `vfox`, `1password`, and `homebrew`.
+    - Unknown rc findings stay structured, counted, and non-error.
+    - Summary output remains count/group based and shared by wizard and config-first rendering.
+  </behavior>
+  <action>In `src/inventory/dotfiles.ts`, implement `parseShellRcFindings(filePath, content)` as a line-oriented text parser only. Recognize alias declarations, simple `name() {` or `function name()` function declarations by function name only, `export NAME=value`, PATH edits that assign or append/prepend to `PATH`, `source` and `.` statements, and known hook patterns derived from existing first-party shell hook generators: `direnv hook`, `vfox activate`, `op signin`, and `brew shellenv`. Implement `classifyRcExportValue(rawValue)` returning value kinds such as `literal`, `reference`, `command-derived`, and `secret-like`; persist only the env var name and value kind in `safeDetails`. For source statements, store only the normalized source target when it is not command substitution; mark command-derived source text as a safe kind rather than storing command text. Integrate parser output into `scanDotfileMap()` for common rc file basenames, including `.zshrc`, `.zprofile`, `.zshenv`, `.bashrc`, `.bash_profile`, `.profile`, and `.envrc`. Keep D-06 boundaries strict: no shell execution, no recursive source expansion, no function body parsing, no arbitrary conditional/control-flow modeling. Update derived map counts and `summarizeInventory()` so rc findings affect concise `Dotfiles:` or `Dotfile findings:` lines without printing raw values or full lines. Preserve the path-map behavior from Plan 03-01.</action>
+  <verify>
+    <automated>npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts</automated>
+    <automated>npm run test:integration -- tests/integration/wizard-flow.test.tsx tests/integration/config-first.test.ts -t inventory</automated>
+    <automated>npm run build</automated>
+    <automated>npm run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - Alias/function/source/path-edit findings preserve names or safe kinds only and do not store command output or function bodies.
+    - Export findings preserve env var names and value kinds only, and serialized `DotfileMap` output omits raw literal, command-derived, backend reference, and token-looking values per D-07/D-08.
+    - Known hook findings have `classification: 'known'` and tool ids for `direnv`, `vfox`, `1password`, or `homebrew`; unknown aliases/functions/sources have `classification: 'unknown'`.
+    - Parse failures or malformed lines cannot reject `scanInventory()`; they become skipped/unknown findings or dotfile warnings per D-12.
+    - Wizard and config-first inventory blocks contain aggregate dotfile/rc counts and omit detailed paths and raw rc content per D-13/D-14/D-15.
+  </acceptance_criteria>
+  <done>DOT-02 and DOT-04 pass with safe rc parsing, unknown finding separation, no raw env value persistence, and shared concise terminal output.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| rc file content -> parser | User-controlled shell text enters a parser that must never execute or deeply model shell behavior. |
+| parser findings -> report data | Potentially sensitive exports are transformed into structured evidence. |
+| report data -> terminal summary | Detailed audit data is compressed into default wizard and config-first output. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-03-05 | Information Disclosure | `parseShellRcFindings()` export parsing | mitigate | Store env var names and value kinds only; tests serialize output and reject raw literal, `op://`, command substitution, and token-looking values. |
+| T-03-06 | Elevation of Privilege | rc hook parsing | mitigate | Parse text only; never call `run`, `execa`, `eval`, shell commands, source expansion, or plugin methods from parser code. |
+| T-03-07 | Denial of Service | malformed rc files | mitigate | Skip unknown/malformed lines or emit dotfile warnings; malformed content must not reject `scanInventory()`. |
+| T-03-08 | Information Disclosure | wizard/config-first output | mitigate | Keep detailed findings in `InventoryReport.dotfiles`; `summarizeInventory()` emits only counts/grouped tool labels and never raw rc lines. |
+| T-03-SC | Tampering | npm installs | mitigate | No package-manager install tasks are allowed in this plan; existing locked dependencies only. |
+</threat_model>
+
+<verification>
+Run after both tasks:
+- `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts`
+- `npm run test:integration -- tests/integration/wizard-flow.test.tsx tests/integration/config-first.test.ts -t inventory`
+- `npm run build`
+- `npm run lint`
+</verification>
+
+<success_criteria>
+- Rc parsing emits aliases, function names, env var names/value kinds, PATH edits, source statements, and known tool hook findings.
+- Raw env values, secret-looking values, backend references, command substitutions, and function bodies are absent from scanner output.
+- Unknown rc findings are separate evidence and not errors.
+- Wizard and config-first inventory output share concise dotfile summary text through `summarizeInventory()`.
+</success_criteria>
+
+<output>
+Create `.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md
@@ -1,0 +1,119 @@
+---
+phase: 03-dotfiles-discovery-map
+plan: 02
+subsystem: inventory
+tags: [dotfiles, rc-parser, inventory, summary, vitest]
+requires:
+  - phase: 03-dotfiles-discovery-map
+    provides: DotfileMap path discovery and shared inventory summary integration from 03-01
+provides:
+  - Safe line-oriented shell rc parser for aliases, functions, exports, PATH edits, sources, and known tool hooks
+  - Rc findings integrated into DotfileMap file summaries and aggregate counts
+  - Shared wizard and config-first dotfile finding summary output through summarizeInventory()
+affects: [inventory, dotfiles, wizard-summary, config-first-summary]
+tech-stack:
+  added: []
+  patterns: [line-oriented shell parsing, safe env value classification, aggregate terminal summaries]
+key-files:
+  created: []
+  modified: [src/inventory/dotfiles.ts, src/inventory/summary.ts, tests/unit/inventory-dotfiles.test.ts, tests/integration/wizard-flow.test.tsx, tests/integration/config-first.test.ts]
+key-decisions:
+  - "Rc parser output stores env names and value kinds only; raw values, command substitutions, and function bodies are not persisted."
+  - "Known rc hooks count as known tool findings while aliases, functions, exports, PATH edits, and source statements remain unknown rc evidence."
+  - "Wizard and config-first output share the new Dotfile findings line from summarizeInventory()."
+patterns-established:
+  - "DotfileMap counts separate known tool hooks from unknown rc findings without counting unmatched-path placeholders."
+  - "Known hook matching is text-only and never invokes shell/plugin commands."
+requirements-completed: [DOT-02, DOT-04]
+duration: 17min
+completed: 2026-06-19
+---
+
+# Phase 03 Plan 02: Rc-File Parsing and Structured Dotfile Output Summary
+
+**Safe shell rc parsing with known hook evidence, unknown finding counts, and shared concise inventory output**
+
+## Performance
+
+- **Duration:** 17 min
+- **Started:** 2026-06-19T22:00:00Z
+- **Completed:** 2026-06-19T22:16:51Z
+- **Tasks:** 2
+- **Files modified:** 5
+
+## Accomplishments
+
+- Added RED coverage for rc parsing, safe env handling, rc integration, and shared wizard/config-first output.
+- Implemented `parseShellRcFindings()` for aliases, function names, env var value kinds, PATH edits, sources, and known `direnv`, `vfox`, `1password`, and `homebrew` hooks.
+- Integrated rc findings into scanned rc-file summaries and added aggregate `knownFindingsCount` / `unknownFindingsCount` values.
+- Extended `summarizeInventory()` with a concise `Dotfile findings:` line used by both wizard and config-first inventory blocks.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add failing rc parsing and shared-output tests** - `9ddafba` (test)
+2. **Task 2: Implement safe rc findings and rc-aware summaries** - `817ae8f` (feat)
+
+**Plan metadata:** this summary commit
+
+_Note: This plan followed the TDD gate with RED then GREEN commits._
+
+## Files Created/Modified
+
+- `src/inventory/dotfiles.ts` - Safe rc parser, known hook matching, rc finding integration, and rc finding counts.
+- `src/inventory/summary.ts` - Shared aggregate `Dotfile findings:` line for terminal inventory output.
+- `tests/unit/inventory-dotfiles.test.ts` - DOT-02/DOT-04 rc parsing and scanner integration coverage.
+- `tests/integration/wizard-flow.test.tsx` - Wizard regression for shared dotfile finding summary and no rc detail leakage.
+- `tests/integration/config-first.test.ts` - Config-first regression for the same shared summary output.
+
+## Decisions Made
+
+- Kept rc parsing line-oriented and text-only; no shell execution, source expansion, or function-body parsing was introduced.
+- Stored source targets only for literal/reference source statements; command-derived source statements are represented by safe kind only.
+- Counted rc finding aggregates separately from path-level metadata findings so default output stays concise.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+---
+
+**Total deviations:** 0 auto-fixed.
+**Impact on plan:** No scope change.
+
+## Issues Encountered
+
+None.
+
+## Verification
+
+- `npm run test -- tests/unit/inventory-dotfiles.test.ts` - RED failed before implementation for missing hook/PATH/map integration; passed after implementation with 5 tests.
+- `npm run test:integration -- tests/integration/wizard-flow.test.tsx tests/integration/config-first.test.ts -t inventory` - RED failed before implementation for missing `Dotfile findings:` output; passed after implementation with 10 tests.
+- `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` - passed, 2 files and 14 tests.
+- `npm run build` - passed.
+- `npm run lint` - passed.
+
+## Known Stubs
+
+None. Stub scan found only normal empty accumulator defaults and test setup locals, not placeholder UI/data paths.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+Phase 3 now has path-level and rc-level dotfile evidence ready for Phase 4 provenance derivation. The structured report preserves details for downstream audit/provenance while default terminal output remains aggregate-only.
+
+## Self-Check: PASSED
+
+- Key modified files exist.
+- Task commits `9ddafba` and `817ae8f` exist in git history.
+- Required verification commands passed.
+- Summary file was created at `.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md`.
+- No raw rc values, backend references, command substitutions, or function bodies are asserted in scanner output by tests.
+
+---
+*Phase: 03-dotfiles-discovery-map*
+*Completed: 2026-06-19*

--- a/.planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md
@@ -1,0 +1,126 @@
+# Phase 3: Dotfiles Discovery Map - Context
+
+**Gathered:** 2026-06-18
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+This phase creates a read-only dotfile discovery map that connects known dotfile paths, tool config paths, shell rc-file contents, workspace config files, and unknown files to structured evidence. It should build on the shared metadata registry and Phase 2 inventory report without assigning final provenance labels. The output should give Phase 4 enough evidence to explain tool provenance while giving users a concise terminal summary of discovered dotfile/config state.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Dotfile Map Shape
+- **D-01:** Use a hybrid map shape: canonical evidence-first findings internally, plus derived tool-grouped summaries for display and downstream summary rendering.
+- **D-02:** Evidence records should preserve path, scan scope, matched metadata/tool id when available, match reason or confidence, finding type, and safe evidence details.
+- **D-03:** A single file can contain mixed findings. File-level summaries should support a mixed known/unknown state, while nested findings carry exact known, unknown, or ambiguous classification.
+- **D-04:** Unknown files and unknown rc-file findings should be reported separately from known tool-owned findings and should not be treated as errors.
+
+### Shell RC Parsing
+- **D-05:** Parse only core shell setup constructs in this phase: aliases/function names, exported variable names, PATH edits, `source`/`.` statements, and known tool init hooks.
+- **D-06:** Do not attempt deep shell interpretation, arbitrary script execution modeling, broad function-body parsing, or full conditional/control-flow analysis in Phase 3.
+- **D-07:** Environment variables discovered in rc files should record names and value kinds only, such as literal, reference, or command-derived. Raw values must not be persisted by default.
+- **D-08:** Secret-looking or sensitive values remain out of planning artifacts and scanner output. This preserves the project security rule that secrets stay as backend references and are not resolved or persisted.
+
+### Scan Scope
+- **D-09:** Use a combined bounded read-only scan: home shell rc files, metadata-declared `configPaths` and `dotfilePaths`, the configured `dotfilesRepo`, and shallow known config locations under configured workspace roots.
+- **D-10:** Workspace scanning should be limited to root-level known files plus shallow allowlisted directories such as `.config/`, `.vscode/`, `.github/`, and tool-specific metadata paths.
+- **D-11:** Workspace traversal must remain deterministic through explicit allowlists, low maximum depth, and safe failure behavior. Do not introduce broad recursive filesystem crawling.
+- **D-12:** Missing paths, unreadable files, and parse failures should produce structured warnings or skipped findings rather than blocking the inventory or wizard flows.
+
+### Output Surface
+- **D-13:** Phase 3 should expose a concise dotfile discovery summary in the existing inventory step rather than adding a new detailed command.
+- **D-14:** Default terminal output should stay small: counts or short grouped lines for known mapped files, unknown files/findings, and warnings. Detailed audit data should remain available in structured report data for later phases.
+- **D-15:** The summary should reuse the established `summarizeInventory`/inventory-step pattern where practical so wizard and config-first output do not drift.
+
+### the agent's Discretion
+- The exact TypeScript type names and module boundaries are planner/executor discretion, but new code should make the dotfile mapping boundary obvious and should fit naturally under the inventory or scanner architecture.
+- The exact allowlist of workspace filenames and shallow directories is discretionary, as long as it is conservative, metadata-driven where possible, and covered by tests.
+- The exact summary wording is discretionary, as long as it remains concise and terminal-scannable.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Project Scope
+- `.planning/PROJECT.md` — Defines the milestone sequence, core value, macOS-first constraint, non-destructive scan rule, and Phase 3 active requirement.
+- `.planning/REQUIREMENTS.md` — Defines Phase 3 requirements `DOT-01` through `DOT-04`.
+- `.planning/ROADMAP.md` — Defines Phase 3 goal, success criteria, and planned slices `03-01` and `03-02`.
+- `.planning/STATE.md` — Records accumulated decisions and project concerns, including not deepening registry inconsistency.
+- `.planning/phases/01-tool-metadata-registry/01-CONTEXT.md` — Locks metadata registry lookup and validation decisions Phase 3 must use.
+- `.planning/phases/02-machine-inventory-scanner/02-CONTEXT.md` — Locks inventory fact shape, evidence-first scanning, startup integration, and concise inventory summary behavior Phase 3 must extend.
+
+### Codebase Maps
+- `.planning/codebase/STACK.md` — Confirms Node.js, TypeScript, Ink, Vitest, and external command mocking constraints.
+- `.planning/codebase/ARCHITECTURE.md` — Describes startup flow, wizard mode layering, config-first flow, and dotfile writer boundaries.
+- `.planning/codebase/INTEGRATIONS.md` — Describes local file storage, external integrations, and mocked command patterns.
+
+### Existing Code
+- `src/tools/metadata.ts` — Defines `configPaths` and `dotfilePaths` metadata fields used for known path matching.
+- `src/tools/registry.ts` — Provides lookup helpers for config path and dotfile path matching.
+- `src/inventory/report.ts` — Defines the Phase 2 inventory report shape and environment snapshot to extend or compose with dotfile mapping data.
+- `src/inventory/scan.ts` — Existing inventory scan orchestration where dotfile discovery may integrate.
+- `src/inventory/summary.ts` — Existing concise summary formatting used by wizard and config-first output.
+- `src/steps/inventory.tsx` — Existing inventory wizard surface where the concise dotfile summary should appear.
+- `src/modes/config-first.tsx` — Config-first surface that should receive the same concise inventory/dotfile summary.
+- `src/capture/scanner.ts` — Existing scan helpers for dotfiles and rc files that can inform Phase 3, even if not preserved as the long-term boundary.
+- `tests/unit/capture-scanner.test.ts` — Existing rc-file and dotfile scan test patterns to adapt or replace.
+- `tests/unit/tool-metadata.test.ts` — Existing metadata lookup tests covering config and dotfile path matching.
+- `tests/integration/wizard-flow.test.tsx` — Existing inventory-step summary tests to extend for concise dotfile output.
+- `tests/integration/config-first.test.ts` — Existing config-first inventory summary tests to extend for concise dotfile output.
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `src/tools/registry.ts`: Already matches exact and child config/dotfile paths from shared metadata.
+- `src/tools/metadata.ts`: Already validates optional `configPaths` and `dotfilePaths`.
+- `src/inventory/report.ts`: Already has evidence-backed facts, warnings, and an environment snapshot containing rc-file content.
+- `src/inventory/summary.ts`: Already centralizes terminal summary lines for wizard and config-first use.
+- `src/capture/scanner.ts`: Already scans home dotfiles and reads a limited rc-file set, useful as a migration source.
+
+### Established Patterns
+- Scanners should fail softly and return warnings instead of crashing user flows.
+- External command behavior is mocked in tests; filesystem scanning should similarly be testable with temporary directories and fixture files.
+- Wizard and config-first output should share summary formatting helpers rather than duplicating text.
+- Phase 2 keeps installed evidence separate from final provenance labels; Phase 3 should do the same for dotfile evidence.
+
+### Integration Points
+- Dotfile mapping should consume shared metadata lookup helpers for known config and dotfile paths.
+- Inventory startup can carry dotfile map data forward so wizard and config-first flows have it before user decisions.
+- The inventory summary helper is the right place to add concise dotfile discovery lines so UI surfaces stay aligned.
+- The detailed map should remain structured data for Phase 4 provenance rather than becoming a large default terminal dump.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Represent files as summaries with nested findings so mixed files like `.zshrc` can show both known tool hooks and unknown aliases without losing precision.
+- Record env var names and value kinds only; do not persist raw values from rc files.
+- Use a conservative workspace allowlist: root-level known config files plus shallow `.config/`, `.vscode/`, `.github/`, and tool-specific metadata paths.
+- Keep the initial summary to counts or short grouped lines such as known mapped files, unknown findings, and warnings.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Final provenance categories such as tilde-managed, manually installed, dependency, OS-provided, app-store/manual GUI install, and unknown remain Phase 4 work.
+- A dedicated detailed dotfile inspection command or verbose output mode is out of scope for Phase 3 unless already required by the planner for testability.
+- Broad recursive workspace crawling, full shell interpretation, and ecosystem-wide search remain out of scope.
+
+</deferred>
+
+---
+
+*Phase: 3-Dotfiles Discovery Map*
+*Context gathered: 2026-06-18*

--- a/.planning/phases/03-dotfiles-discovery-map/03-DISCUSSION-LOG.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-DISCUSSION-LOG.md
@@ -1,0 +1,108 @@
+# Phase 3: Dotfiles Discovery Map - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-06-18
+**Phase:** 3-Dotfiles Discovery Map
+**Areas discussed:** Map Shape, RC Parsing, Scan Scope, Output Surface
+
+---
+
+## Map Shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Evidence-first records | Each finding records path, source scope, matched tool metadata, match confidence/reason, and raw-safe evidence. | |
+| Tool-first grouping | Group findings under each known tool, with unknown files in a separate bucket. | |
+| Hybrid | Store evidence-first records internally, plus derived tool-grouped summaries for display. | ✓ |
+
+**User's choice:** Hybrid.
+**Notes:** The user selected canonical evidence records plus derived grouped summaries so Phase 4 can consume precise evidence while users see concise terminal output.
+
+### Ambiguous Matches
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Classify per finding | One file can produce multiple findings such as known tool hook, PATH edit, and unknown alias. | |
+| Classify per file by strongest match | Mark the whole file as known if any known tool is found, with secondary notes. | |
+| Known file plus nested findings | File-level summary says mixed known/unknown, then nested findings carry exact classification. | ✓ |
+
+**User's choice:** Known file plus nested findings.
+**Notes:** Mixed files should stay readable at the file level while preserving exact known, unknown, and ambiguous findings underneath.
+
+---
+
+## RC Parsing
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Core shell setup only | Parse aliases/functions names, exported variable names, PATH edits, source statements, and known tool init hooks. | ✓ |
+| Broad shell inventory | Include function bodies, conditionals, plugin manager blocks, and command substitutions. | |
+| Known-tool oriented | Parse only metadata or known tool patterns, plus unknown line-count summaries. | |
+
+**User's choice:** Core shell setup only.
+**Notes:** Phase 3 should satisfy rc-file discovery without becoming a shell interpreter.
+
+### Environment Variable Values
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Names only by default | Record variable names and whether values are literal/reference/command-derived, but do not persist raw values. | ✓ |
+| Safe literals allowed | Persist simple non-secret literals after secret-pattern filtering; redact suspicious values. | |
+| No env var details | Only count exported variables and flag known tool-related names. | |
+
+**User's choice:** Names only by default.
+**Notes:** This keeps rc parsing aligned with the project security rule against persisting raw secrets.
+
+---
+
+## Scan Scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Home + metadata paths | Scan known shell rc files in `$HOME` and metadata-declared config/dotfile paths. | |
+| Home + metadata + configured workspace roots | Also scan configured context/workspace roots for known config filenames. | |
+| Home + metadata + dotfiles repo | Also scan the configured `dotfilesRepo`. | |
+| Combined bounded scan | Scan home rc files, metadata-declared paths, configured `dotfilesRepo`, and shallow known config names under configured workspace roots. | ✓ |
+
+**User's choice:** Combined bounded scan.
+**Notes:** Scope should satisfy DOT-03 while remaining deterministic and read-only.
+
+### Workspace Bounds
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Root-level known files only | Check only known filenames at the workspace root. | |
+| Shallow allowlisted directories | Check root plus selected directories like `.config/`, `.vscode/`, `.github/`, and tool-specific metadata paths, with a low max depth. | ✓ |
+| Respect ignore files and scan shallow tree | Walk a shallow tree while applying `.gitignore`/ignore rules. | |
+
+**User's choice:** Shallow allowlisted directories.
+**Notes:** Workspace scans should avoid broad traversal and stay easy to reason about in tests.
+
+---
+
+## Output Surface
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Structured data only | Build the dotfile map and tests; user-facing summaries wait for Phase 4 provenance. | |
+| Concise summary in inventory step | Add a small "Dotfiles found" summary alongside current inventory output, while keeping detailed audit data internal. | ✓ |
+| Dedicated detail command/output | Add a specific CLI path or verbose output for dotfile findings. | |
+
+**User's choice:** Concise summary in inventory step.
+**Notes:** Phase 3 should expose small summary lines now, not a new detailed command.
+
+---
+
+## the agent's Discretion
+
+- Exact type names and module placement.
+- Exact conservative filename and directory allowlists for workspace scanning.
+- Exact terminal summary wording, as long as it is concise and shared between wizard and config-first surfaces.
+
+## Deferred Ideas
+
+- Final provenance labels remain Phase 4.
+- Dedicated detailed dotfile inspection command or verbose output mode is deferred.
+- Broad recursive workspace crawling and full shell interpretation are out of scope.

--- a/.planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-PATTERNS.md
@@ -1,0 +1,670 @@
+# Phase 03: Dotfiles Discovery Map - Pattern Map
+
+**Mapped:** 2026-06-19
+**Files analyzed:** 8
+**Analogs found:** 8 / 8
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `src/inventory/dotfiles.ts` | service/utility | file-I/O, transform | `src/capture/scanner.ts`, `src/capture/parser.ts`, `src/tools/registry.ts` | role-match |
+| `src/inventory/report.ts` | model | transform | `src/inventory/report.ts` | exact |
+| `src/inventory/scan.ts` | service | batch, file-I/O | `src/inventory/scan.ts` | exact |
+| `src/inventory/summary.ts` | utility | transform | `src/inventory/summary.ts` | exact |
+| `src/tools/metadata.ts` | model/config | transform | `src/tools/metadata.ts` | exact |
+| `src/tools/registry.ts` | utility | transform | `src/tools/registry.ts` | exact |
+| `tests/unit/inventory-dotfiles.test.ts` | test | file-I/O, transform | `tests/unit/capture-scanner.test.ts`, `tests/unit/tool-metadata.test.ts` | role-match |
+| `tests/unit/inventory-scanner.test.ts`, `tests/integration/wizard-flow.test.tsx`, `tests/integration/config-first.test.ts` | test | request-response, transform | existing same files | exact |
+
+## Pattern Assignments
+
+### `src/inventory/dotfiles.ts` (service/utility, file-I/O + transform)
+
+**Analogs:** `src/capture/scanner.ts`, `src/capture/parser.ts`, `src/tools/registry.ts`, `src/inventory/scan.ts`
+
+**Imports pattern** (`src/capture/scanner.ts` lines 1-5):
+```typescript
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import fg from 'fast-glob';
+import { run } from '../utils/exec.js';
+import { detectLanguages, detectVersionManagers, type DetectedLanguage, type DetectedVersionManager } from '../utils/env-detection.js';
+```
+
+Copy the NodeNext ESM style and `.js` relative import extensions, but do not import `run` for dotfile parsing. Phase 3 discovery must stay read-only and must not execute shell content.
+
+**Bounded home dotfile scan pattern** (`src/capture/scanner.ts` lines 16-25):
+```typescript
+const RC_FILE_NAMES = ['.zshrc', '.zshprofile', '.gitconfig'];
+
+export async function scanDotfiles(homeDir: string): Promise<string[]> {
+  const paths = await fg([`${homeDir}/.*`], {
+    onlyFiles: true,
+    deep: 1,
+    dot: true,
+  });
+  return paths;
+}
+```
+
+Use this shape for shallow home scans and adapt it for workspace allowlists. Keep `onlyFiles`, `dot`, and low `deep`; do not introduce broad recursive crawling.
+
+**Safe rc-file read pattern** (`src/capture/scanner.ts` lines 36-47):
+```typescript
+export async function scanRcFiles(dotfilePaths: string[]): Promise<Record<string, string>> {
+  const rcPaths = dotfilePaths.filter(p => RC_FILE_NAMES.includes(basename(p)));
+  const result: Record<string, string> = {};
+  await Promise.all(
+    rcPaths.map(async (filePath) => {
+      const name = basename(filePath);
+      const content = await readFile(filePath, 'utf-8');
+      result[name] = content;
+    })
+  );
+  return result;
+}
+```
+
+For the new mapper, wrap each read so missing/unreadable files become dotfile warnings/skipped findings rather than rejecting the whole scan.
+
+**Small line parser pattern** (`src/capture/parser.ts` lines 12-24, 38-47):
+```typescript
+for (const line of content.split('\n')) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) continue;
+
+  // Parse aliases: alias foo='bar' or alias foo=bar
+  const aliasMatch = trimmed.match(/^alias\s+([^=\s]+)=(.+)$/);
+  if (aliasMatch) {
+    const key = aliasMatch[1].trim();
+    let value = aliasMatch[2].trim();
+    value = value.replace(/^(['"])(.*)\1$/, '$2');
+    aliases[key] = value;
+    continue;
+  }
+
+  // Parse source / . lines
+  const sourceMatch = trimmed.match(/^(?:source|\.)\s+(.+)$/);
+  if (sourceMatch) {
+    let src = sourceMatch[1].trim();
+    src = src.replace(/^(['"])(.*)\1$/, '$2');
+    sourcedFiles.push(src);
+  }
+}
+```
+
+Copy the simple line-oriented approach for aliases, functions, exports, PATH edits, source lines, and known init hooks. Do not copy the export value persistence from lines 26-35; Phase 3 should record env var names and value kinds only.
+
+**Metadata path matching pattern** (`src/tools/registry.ts` lines 57-63, 95-105):
+```typescript
+export function getToolsByConfigPath(path: string): ToolMetadata[] {
+  return allToolMetadata.filter(tool => tool.configPaths?.some(configPath => pathMatches(configPath, path)));
+}
+
+export function getToolsByDotfilePath(path: string): ToolMetadata[] {
+  return allToolMetadata.filter(tool => tool.dotfilePaths?.some(dotfilePath => pathMatches(dotfilePath, path)));
+}
+
+function pathMatches(knownPath: string, queryPath: string): boolean {
+  const normalizedKnownPath = normalizePath(knownPath);
+  const normalizedQueryPath = normalizePath(queryPath);
+
+  return normalizedQueryPath === normalizedKnownPath ||
+    normalizedQueryPath.startsWith(`${normalizedKnownPath}/`);
+}
+
+function normalizePath(path: string): string {
+  return path.trim().replace(/\/+$/, '');
+}
+```
+
+Use these helpers directly for known path findings. Do not reimplement per-tool matching.
+
+**Warning instead of throw pattern** (`src/inventory/scan.ts` lines 167-176):
+```typescript
+async function scanEnvironmentRcFiles(homeDir: string, warnings: InventoryWarning[]): Promise<Record<string, string>> {
+  try {
+    const filter = createCaptureFilter();
+    const dotfiles = await scanDotfiles(homeDir);
+    const { included } = filterDotfiles(dotfiles, filter);
+    return await scanRcFiles(included);
+  } catch {
+    warnings.push(createWarning('environment', 'Shell and git rc files could not be read; related wizard defaults may be unavailable.'));
+    return {};
+  }
+}
+```
+
+The new dotfile scan should follow this soft-failure contract, preferably with per-path warnings when possible.
+
+---
+
+### `src/inventory/report.ts` (model, transform)
+
+**Analog:** `src/inventory/report.ts`
+
+**Typed evidence pattern** (lines 9-19):
+```typescript
+export type InventoryWarningSeverity = 'info' | 'warning' | 'error';
+
+export type InventoryWarningSource = 'homebrew' | 'environment' | 'app-path' | 'scanner';
+
+export type InventoryEvidence =
+  | { type: 'homebrew-formula'; id: string; requestStatus: HomebrewRequestStatus }
+  | { type: 'homebrew-cask'; id: string; requestStatus: Extract<HomebrewRequestStatus, 'direct'> }
+  | { type: 'app-path'; path: string; exists: boolean }
+  | { type: 'command'; command: string; outcome: 'succeeded' | 'failed' | 'unknown'; version?: string }
+  | { type: 'shell'; name: string; source: 'process-env' | 'scanner' }
+  | { type: 'inconclusive'; source: InventoryWarningSource; reason: string; warningId?: string };
+```
+
+Add dotfile-specific union types rather than loose objects. Extend `InventoryWarningSource` with a dotfile-oriented source such as `'dotfiles'` if dotfile warnings need their own bucket.
+
+**Report section pattern** (lines 55-69):
+```typescript
+export interface InventoryEnvironmentSnapshot {
+  homeDir: string;
+  shell?: string;
+  rcFiles: Record<string, string>;
+  detectedLanguages: DetectedLanguage[];
+  detectedVersionManagers: DetectedVersionManager[];
+}
+
+export interface InventoryReport {
+  tools: InventoryToolFact[];
+  unmatchedHomebrew: InventoryHomebrewAudit;
+  homebrew: InventoryHomebrewSummary;
+  warnings: InventoryWarning[];
+  environment: InventoryEnvironmentSnapshot;
+}
+```
+
+Add a top-level `dotfiles` or `dotfileMap` section to `InventoryReport`, not a UI-only structure. Keep raw rc content confined to the existing environment snapshot; new dotfile findings must use safe details.
+
+**Empty report defaults pattern** (lines 78-104):
+```typescript
+export function createEmptyInventoryReport(homeDir = process.env.HOME ?? '~'): InventoryReport {
+  return {
+    tools: [],
+    unmatchedHomebrew: {
+      formulae: [],
+      casks: [],
+    },
+    homebrew: {
+      installedFormulaeCount: 0,
+      installedCasksCount: 0,
+      matchedFormulaeCount: 0,
+      matchedCasksCount: 0,
+      unmatchedFormulaeCount: 0,
+      unmatchedCasksCount: 0,
+      directFormulaeCount: 0,
+      dependencyFormulaeCount: 0,
+      unknownFormulaeCount: 0,
+    },
+    warnings: [],
+    environment: {
+      homeDir,
+      shell: process.env.SHELL,
+      rcFiles: {},
+      detectedLanguages: [],
+      detectedVersionManagers: [],
+    },
+  };
+}
+```
+
+Add an empty dotfile map here so failed/loading inventory surfaces can render deterministically.
+
+---
+
+### `src/inventory/scan.ts` (service, batch + file-I/O)
+
+**Analog:** `src/inventory/scan.ts`
+
+**Orchestration pattern** (lines 33-51):
+```typescript
+export async function scanInventory(homeDir?: string): Promise<InventoryReport> {
+  const resolvedHome = homeDir ?? process.env.HOME ?? '~';
+  const report = createEmptyInventoryReport(resolvedHome);
+  const warnings = report.warnings;
+  const homebrew = await scanHomebrew(warnings);
+  const formulaMap = homebrew.formulae === null
+    ? null
+    : new Map(homebrew.formulae.map(formula => [formula.id, formula]));
+  const caskMap = homebrew.casks === null
+    ? null
+    : new Map(homebrew.casks.map(cask => [cask.id, cask]));
+
+  report.environment = {
+    homeDir: resolvedHome,
+    shell: process.env.SHELL,
+    rcFiles: await scanEnvironmentRcFiles(resolvedHome, warnings),
+    detectedLanguages: await scanDetectedLanguages(warnings),
+    detectedVersionManagers: await scanDetectedVersionManagers(warnings),
+  };
+```
+
+Attach dotfile mapping inside `scanInventory()` after resolving `homeDir` and before return. Pass the shared `warnings` array so failures appear in the existing summary channel.
+
+**Report completion pattern** (lines 77-99):
+```typescript
+report.tools.push(...createShellFacts(report.environment.shell));
+report.tools.push(...createCoreToolFacts(report.environment.detectedLanguages, report.environment.detectedVersionManagers));
+
+report.unmatchedHomebrew = {
+  formulae: homebrew.formulae?.filter(formula => !matchedFormulae.has(formula.id)) ?? [],
+  casks: homebrew.casks?.filter(cask => !matchedCasks.has(cask.id)) ?? [],
+};
+
+const requestStatusCounts = countFormulaRequestStatuses(homebrew.formulae ?? []);
+
+report.homebrew = {
+  installedFormulaeCount: homebrew.formulae?.length ?? 0,
+  installedCasksCount: homebrew.casks?.length ?? 0,
+  matchedFormulaeCount: matchedFormulae.size,
+  matchedCasksCount: matchedCasks.size,
+  unmatchedFormulaeCount: report.unmatchedHomebrew.formulae.length,
+  unmatchedCasksCount: report.unmatchedHomebrew.casks.length,
+  directFormulaeCount: requestStatusCounts.direct,
+  dependencyFormulaeCount: requestStatusCounts.dependency,
+  unknownFormulaeCount: requestStatusCounts.unknown,
+};
+
+return report;
+```
+
+Keep dotfile summary counts derived from structured findings in the report, not recomputed in UI components.
+
+**Path check soft-failure pattern** (lines 296-327):
+```typescript
+async function checkAppPath(
+  toolId: string,
+  appPath: string,
+  warnings: InventoryWarning[]
+): Promise<{ evidence: InventoryEvidence; warningIds: string[] }> {
+  try {
+    await access(appPath);
+    return {
+      evidence: { type: 'app-path', path: appPath, exists: true },
+      warningIds: [],
+    };
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return {
+        evidence: { type: 'app-path', path: appPath, exists: false },
+        warningIds: [],
+      };
+    }
+
+    const warning = createWarning('app-path', `Could not check app path for ${toolId}; app bundle state is unknown.`, toolId);
+    warnings.push(warning);
+    return {
+      evidence: {
+        type: 'inconclusive',
+        source: 'app-path',
+        reason: `Could not check app path ${appPath}.`,
+        warningId: warning.id,
+      },
+      warningIds: [warning.id],
+    };
+  }
+}
+```
+
+Use the same distinction for missing dotfiles versus unreadable/failed dotfiles: missing candidates can be skipped or marked absent; unexpected read failures should become warnings.
+
+---
+
+### `src/inventory/summary.ts` (utility, transform)
+
+**Analog:** `src/inventory/summary.ts`
+
+**Concise summary pattern** (lines 7-25):
+```typescript
+export function summarizeInventory(report: InventoryReport): string[] {
+  const installedKnownTools = getInstalledKnownToolFacts(report);
+  const installedKnownToolSummary = installedKnownTools.length > 0
+    ? installedKnownTools.map(tool => tool.label).join(', ')
+    : 'none';
+  const lines = [
+    `Known installed tools: ${installedKnownToolSummary}`,
+    `Homebrew formulae: ${report.homebrew.directFormulaeCount} direct, ${report.homebrew.dependencyFormulaeCount} dependencies, ${report.homebrew.unknownFormulaeCount} unknown`,
+    `Homebrew casks: ${report.homebrew.installedCasksCount} installed, ${report.homebrew.unmatchedCasksCount} unmatched`,
+  ];
+
+  if (report.warnings.length > 0) {
+    lines.push('Warnings:');
+    for (const warning of report.warnings) {
+      lines.push(`Warning: ${warning.message}`);
+    }
+  }
+
+  return lines;
+}
+```
+
+Add one or two dotfile lines before warnings, using counts/grouped labels only. Do not list every unknown path in default output.
+
+**UI consumption pattern** (`src/steps/inventory.tsx` lines 39-50):
+```typescript
+return (
+  <Box flexDirection="column">
+    <Text bold>{heading}</Text>
+    <Box marginTop={1} flexDirection="column">
+      {summarizeInventory(report).map(line => (
+        <Text
+          key={line}
+          color={line.startsWith('Warning') ? 'yellow' : 'green'}
+        >
+          {line}
+        </Text>
+      ))}
+    </Box>
+```
+
+Because wizard and config-first both call `summarizeInventory()`, keep dotfile wording centralized here.
+
+---
+
+### `src/tools/metadata.ts` and `src/tools/registry.ts` (model/config + utility, transform)
+
+**Analogs:** same files
+
+**Metadata fields pattern** (`src/tools/metadata.ts` lines 47-58):
+```typescript
+export const ToolMetadataSchema = z.object({
+  id: NonBlankStringSchema,
+  label: NonBlankStringSchema,
+  category: ToolCategorySchema,
+  supportedPlatforms: z.array(PlatformSchema).min(1),
+  source: z.enum(['first-party', 'community', 'local']).default('first-party'),
+  install: ToolInstallSchema,
+  externalIds: ToolExternalIdsSchema,
+  configPaths: z.array(NonBlankStringSchema).optional(),
+  dotfilePaths: z.array(NonBlankStringSchema).optional(),
+  variants: z.array(NonBlankStringSchema).optional(),
+});
+```
+
+Reuse these existing fields for known file matching. If adding metadata rows, keep path strings nonblank and control-character-free through the existing schema.
+
+**Validation error pattern** (`src/tools/metadata.ts` lines 80-90):
+```typescript
+export function validateToolMetadata(metadata: unknown): ToolMetadata[] {
+  const parsed = ToolMetadataArraySchema.safeParse(metadata);
+
+  if (!parsed.success) {
+    const details = parsed.error.issues
+      .map(issue => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+      .join('; ');
+    throw new Error(`Invalid tool metadata: ${details}`);
+  }
+
+  return parsed.data;
+}
+```
+
+Prefer schema-backed metadata expansion over ad hoc validation in the scanner.
+
+**Lookup test pattern** (`tests/unit/tool-metadata.test.ts` lines 223-229):
+```typescript
+it('META-04/D-14 matches exact and child config and dotfile paths', () => {
+  expect(getToolsByConfigPath('~/Library/Application Support/obsidian').map(tool => tool.id)).toEqual(['obsidian']);
+  expect(getToolsByConfigPath('~/Library/Application Support/obsidian/plugins').map(tool => tool.id)).toEqual(['obsidian']);
+  expect(getToolsByDotfilePath('~/.obsidian').map(tool => tool.id)).toEqual(['obsidian']);
+  expect(getToolsByDotfilePath('~/.obsidian/snippets/theme.css').map(tool => tool.id)).toEqual(['obsidian']);
+  expect(getToolsByConfigPath('~/Library/Application Support/missing')).toEqual([]);
+});
+```
+
+Extend this when adding or adjusting metadata paths.
+
+---
+
+### Tests (unit and integration)
+
+**Analogs:** `tests/unit/inventory-scanner.test.ts`, `tests/unit/capture-scanner.test.ts`, `tests/unit/tool-metadata.test.ts`, `tests/integration/wizard-flow.test.tsx`, `tests/integration/config-first.test.ts`
+
+**Temp filesystem fixture pattern** (`tests/unit/capture-scanner.test.ts` lines 14-24):
+```typescript
+beforeEach(async () => {
+  tmpHome = join(tmpdir(), `tilde-scanner-test-${randomUUID()}`);
+  await mkdir(tmpHome, { recursive: true });
+  await writeFile(join(tmpHome, '.zshrc'), 'alias gs="git status"\nexport PATH=/usr/local/bin\n');
+  await writeFile(join(tmpHome, '.gitconfig'), '[user]\n  name = Test User\n  email = test@example.com\n');
+  await writeFile(join(tmpHome, '.env'), 'SECRET=hunter2\n');
+});
+
+afterEach(async () => {
+  await rm(tmpHome, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+```
+
+Use temp dirs for `inventory-dotfiles.test.ts`; include rc files, metadata-matched files, unknown files, unreadable/missing cases, and shallow workspace fixtures.
+
+**Scanner mock pattern** (`tests/unit/inventory-scanner.test.ts` lines 7-35, 93-99):
+```typescript
+const {
+  mockListInstalledFormulae,
+  mockListInstalledCasks,
+  mockListInstalledOnRequestFormulae,
+  mockDetectLanguages,
+  mockDetectVersionManagers,
+  mockAccess,
+} = vi.hoisted(() => ({
+  mockListInstalledFormulae: vi.fn(),
+  mockListInstalledCasks: vi.fn(),
+  mockListInstalledOnRequestFormulae: vi.fn(),
+  mockDetectLanguages: vi.fn(),
+  mockDetectVersionManagers: vi.fn(),
+  mockAccess: vi.fn(),
+}));
+
+vi.mock('../../src/tools/registry.js', () => ({
+  allToolMetadata: [
+    {
+      id: 'homebrew',
+      label: 'Homebrew',
+      category: 'package-manager',
+      supportedPlatforms: ['darwin'],
+      source: 'first-party',
+      install: {
+        manualNote: 'Install from https://brew.sh',
+      },
+    },
+  ],
+}));
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  return {
+    ...actual,
+    access: mockAccess,
+  };
+});
+```
+
+Use `vi.hoisted()` and module mocks when scanner behavior depends on registry metadata or filesystem edge cases.
+
+**Evidence assertion pattern** (`tests/unit/inventory-scanner.test.ts` lines 140-175):
+```typescript
+const report = await scanInventory(tmpHome);
+
+expect(report).toEqual(expect.objectContaining({
+  tools: expect.any(Array),
+  unmatchedHomebrew: expect.any(Object),
+  homebrew: expect.any(Object),
+  warnings: expect.any(Array),
+  environment: expect.any(Object),
+}));
+
+const formulaFact = report.tools.find(tool => tool.toolId === 'test-cli');
+expect(formulaFact).toEqual(expect.objectContaining({
+  installed: 'installed',
+  evidence: expect.arrayContaining([
+    expect.objectContaining({ type: 'homebrew-formula', id: 'test-cli' }),
+  ]),
+}));
+```
+
+Assert dotfile report shape and nested findings with `expect.objectContaining()` / `expect.arrayContaining()` so tests stay focused on behavior.
+
+**Wizard summary assertion pattern** (`tests/integration/wizard-flow.test.tsx` lines 320-347):
+```typescript
+it('inventory wizard step summarizes Homebrew counts and warnings without unmatched names', async () => {
+  const { Wizard } = await import('../../src/modes/wizard.js');
+  const inventory = createInventoryFixture({
+    warnings: [
+      {
+        id: 'homebrew-request-state-unavailable',
+        source: 'homebrew',
+        severity: 'warning',
+        message: 'Homebrew direct/dependency status is unavailable.',
+      },
+    ],
+  });
+
+  const { lastFrame } = render(
+    React.createElement(Wizard, {
+      initialStep: 1,
+      inventory,
+    } as React.ComponentProps<typeof Wizard> & { inventory: InventoryReport })
+  );
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+  const frame = lastFrame() ?? '';
+  expect(frame).toContain('Inventory scan complete');
+  expect(frame).toContain('Known installed tools:');
+  expect(frame).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
+  expect(frame).toContain('Warnings:');
+  expect(frame).toContain('Warning: Homebrew direct/dependency status is unavailable.');
+  expect(frame).not.toContain('ripgrep');
+});
+```
+
+Extend this test with dotfile summary lines and negative assertions that detailed unknown paths do not flood the default UI.
+
+**Config-first summary assertion pattern** (`tests/integration/config-first.test.ts` lines 103-128):
+```typescript
+it('renders inventory summary before configuration summary', async () => {
+  const { ConfigFirstMode } = await import('../../src/modes/config-first.js');
+  const onComplete = vi.fn();
+  const inventoryState: InventoryScanState = {
+    status: 'ready',
+    report: createInventoryFixture(),
+  };
+  const { lastFrame } = render(
+    React.createElement(ConfigFirstMode, { configPath: fixturePath, onComplete, inventoryState })
+  );
+
+  await new Promise((r) => setTimeout(r, 300));
+
+  const frame = lastFrame() ?? '';
+  const inventoryIndex = frame.indexOf('Inventory scan complete');
+  const configIndex = frame.indexOf('Configuration Summary');
+  expect(inventoryIndex).toBeGreaterThanOrEqual(0);
+  expect(configIndex).toBeGreaterThanOrEqual(0);
+  expect(inventoryIndex).toBeLessThan(configIndex);
+  const inventoryBlock = frame.slice(inventoryIndex, configIndex);
+  expect(inventoryBlock).toContain('Known installed tools: Homebrew');
+  expect(inventoryBlock).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
+  expect(inventoryBlock).toContain('Warnings:');
+  expect(inventoryBlock).toContain('Warning: Homebrew direct/dependency status is unavailable.');
+  expect(inventoryBlock).not.toContain('ripgrep');
+});
+```
+
+Mirror wizard assertions here so both surfaces stay aligned through `summarizeInventory()`.
+
+## Shared Patterns
+
+### NodeNext Imports
+**Source:** `src/inventory/scan.ts` lines 1-22  
+**Apply to:** all new/modified TypeScript source files
+```typescript
+import { access } from 'node:fs/promises';
+import { createCaptureFilter, filterDotfiles } from '../capture/filter.js';
+import { scanDotfiles, scanRcFiles } from '../capture/scanner.js';
+import { allToolMetadata } from '../tools/registry.js';
+import type { ToolMetadata } from '../tools/metadata.js';
+```
+
+Use relative imports with `.js` extensions and `import type` for type-only imports.
+
+### Secret and Dotfile Filtering
+**Source:** `src/capture/filter.ts` lines 5-16  
+**Apply to:** `src/inventory/dotfiles.ts`, scanner integration tests
+```typescript
+export function createCaptureFilter(extraPatterns?: string[]) {
+  const filter = ignore().add(defaultSecretPatterns);
+  if (extraPatterns) {
+    filter.add(extraPatterns);
+  }
+  return filter;
+}
+
+export function filterDotfiles(
+  paths: string[],
+  filter: ReturnType<typeof createCaptureFilter>
+): { included: string[]; excluded: string[] } {
+```
+
+Reuse this existing filter or its pattern for sensitive files. Do not persist raw env values from rc exports.
+
+### Soft Failure Warnings
+**Source:** `src/inventory/scan.ts` lines 131-155, 379-386  
+**Apply to:** scan orchestration and dotfile read failures
+```typescript
+async function scanHomebrewList(
+  name: 'formulae' | 'casks',
+  helper: () => Promise<string[]>,
+  warnings: InventoryWarning[]
+): Promise<string[] | null> {
+  try {
+    return await helper();
+  } catch {
+    warnings.push(createWarning('homebrew', `Homebrew ${name} could not be read; related inventory facts are unknown.`));
+    return null;
+  }
+}
+
+function createWarning(source: InventoryWarningSource, message: string, toolId?: string, id?: string): InventoryWarning {
+  return {
+    id: id ?? `${source}:${message}`,
+    source,
+    severity: 'warning',
+    message,
+    toolId,
+  };
+}
+```
+
+Unknown files are evidence, not failures. Missing/unreadable/parse-failed paths should be warnings or skipped findings that leave the report usable.
+
+### Centralized Summary Rendering
+**Source:** `src/modes/config-first.tsx` lines 185-193 and `src/steps/inventory.tsx` lines 39-50  
+**Apply to:** summary changes only through `src/inventory/summary.ts`
+```typescript
+{inventoryReport && (
+  <Box flexDirection="column">
+    <Text bold>{inventoryHeading}</Text>
+    <Box marginTop={1} flexDirection="column">
+      {summarizeInventory(inventoryReport).map(line => (
+        <Text
+          key={line}
+          color={line.startsWith('Warning') ? 'yellow' : 'green'}
+```
+
+Do not duplicate dotfile summary wording inside Ink components.
+
+## No Analog Found
+
+No planned file lacks an analog. The only partial gap is the exact Phase 3 dotfile map shape; use the existing inventory report/evidence patterns plus the locked decisions from `03-CONTEXT.md`.
+
+## Metadata
+
+**Analog search scope:** `src/inventory/`, `src/capture/`, `src/tools/`, `src/steps/`, `src/modes/`, `tests/unit/`, `tests/integration/`  
+**Files scanned:** 15  
+**Pattern extraction date:** 2026-06-19

--- a/.planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
@@ -307,16 +307,16 @@ if (report.dotfiles) {
 | A1 | Known tool init hooks can start with a small curated set such as `direnv hook`, `vfox activate`, and editor/tool-specific source lines. [ASSUMED] | Architecture Patterns | Planner may need user confirmation or codebase-specific hook list before implementation. |
 | A2 | Workspace root scan should include common root files like `package.json` and `tsconfig.json` only if mapped through metadata or clearly useful for context. [ASSUMED] | Architecture Patterns | Planner could over-scan unless it keeps the allowlist conservative. |
 
-## Open Questions
+## Open Questions (RESOLVED)
 
 1. **Should `dotfileMap` live directly on `InventoryReport` or under `environment`?**
    - What we know: `InventoryReport` already separates tools, Homebrew audit, warnings, and environment snapshot. [VERIFIED: src/inventory/report.ts]
-   - What's unclear: Whether planners prefer a top-level `dotfiles` section for Phase 4 consumption.
+   - RESOLVED: Store the map as a top-level `InventoryReport.dotfiles` field, with implementation names using `dotfiles`/`DotfileMap` rather than nesting it under `environment`.
    - Recommendation: Use a top-level `dotfiles` section because it is not just environment defaults; it is provenance evidence. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
 
 2. **Which metadata rows should gain config paths in Plan 03-01?**
    - What we know: Current paths are sparse. [VERIFIED: src/plugins/first-party/neovim/metadata.ts] [VERIFIED: src/plugins/first-party/zed/metadata.ts] [VERIFIED: src/tools/note-taking-metadata.ts]
-   - What's unclear: Exact macOS config paths for every first-party tool were not externally verified before the orchestrator timeout.
+   - RESOLVED: No additional metadata rows are required to gain config paths in Plan 03-01. The path-mapping slice should consume and test the repo-backed rows already verified locally: `neovim.configPaths = ['~/.config/nvim']`, `zed.configPaths = ['~/.config/zed']`, `obsidian.configPaths = ['~/Library/Application Support/obsidian']`, and `obsidian.dotfilePaths = ['~/.obsidian']`. Do not add speculative paths for VS Code, Cursor, browsers, JetBrains, Notion, Bear, vfox, or Homebrew in Phase 3 unless implementation finds repo-local evidence and adds paired metadata tests in the same change.
    - Recommendation: Only add paths already known from code/docs or covered by tests; do not invent broad rows. [VERIFIED: AGENTS.md]
 
 ## Environment Availability

--- a/.planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-RESEARCH.md
@@ -1,0 +1,417 @@
+# Phase 03: Dotfiles Discovery Map - Research
+
+**Researched:** 2026-06-19
+**Domain:** TypeScript CLI filesystem discovery, metadata path matching, shell rc evidence parsing
+**Confidence:** HIGH for codebase integration; MEDIUM for shell parsing heuristics
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01:** Use a hybrid map shape: canonical evidence-first findings internally, plus derived tool-grouped summaries for display and downstream summary rendering.
+- **D-02:** Evidence records should preserve path, scan scope, matched metadata/tool id when available, match reason or confidence, finding type, and safe evidence details.
+- **D-03:** A single file can contain mixed findings. File-level summaries should support a mixed known/unknown state, while nested findings carry exact known, unknown, or ambiguous classification.
+- **D-04:** Unknown files and unknown rc-file findings should be reported separately from known tool-owned findings and should not be treated as errors.
+- **D-05:** Parse only core shell setup constructs in this phase: aliases/function names, exported variable names, PATH edits, `source`/`.` statements, and known tool init hooks.
+- **D-06:** Do not attempt deep shell interpretation, arbitrary script execution modeling, broad function-body parsing, or full conditional/control-flow analysis in Phase 3.
+- **D-07:** Environment variables discovered in rc files should record names and value kinds only, such as literal, reference, or command-derived. Raw values must not be persisted by default.
+- **D-08:** Secret-looking or sensitive values remain out of planning artifacts and scanner output. This preserves the project security rule that secrets stay as backend references and are not resolved or persisted.
+- **D-09:** Use a combined bounded read-only scan: home shell rc files, metadata-declared `configPaths` and `dotfilePaths`, the configured `dotfilesRepo`, and shallow known config locations under configured workspace roots.
+- **D-10:** Workspace scanning should be limited to root-level known files plus shallow allowlisted directories such as `.config/`, `.vscode/`, `.github/`, and tool-specific metadata paths.
+- **D-11:** Workspace traversal must remain deterministic through explicit allowlists, low maximum depth, and safe failure behavior. Do not introduce broad recursive filesystem crawling.
+- **D-12:** Missing paths, unreadable files, and parse failures should produce structured warnings or skipped findings rather than blocking the inventory or wizard flows.
+- **D-13:** Phase 3 should expose a concise dotfile discovery summary in the existing inventory step rather than adding a new detailed command.
+- **D-14:** Default terminal output should stay small: counts or short grouped lines for known mapped files, unknown files/findings, and warnings. Detailed audit data should remain available in structured report data for later phases.
+- **D-15:** The summary should reuse the established `summarizeInventory`/inventory-step pattern where practical so wizard and config-first output do not drift.
+
+### the agent's Discretion
+- The exact TypeScript type names and module boundaries are planner/executor discretion, but new code should make the dotfile mapping boundary obvious and should fit naturally under the inventory or scanner architecture.
+- The exact allowlist of workspace filenames and shallow directories is discretionary, as long as it is conservative, metadata-driven where possible, and covered by tests.
+- The exact summary wording is discretionary, as long as it remains concise and terminal-scannable.
+
+### Deferred Ideas (OUT OF SCOPE)
+- Final provenance categories such as tilde-managed, manually installed, dependency, OS-provided, app-store/manual GUI install, and unknown remain Phase 4 work.
+- A dedicated detailed dotfile inspection command or verbose output mode is out of scope for Phase 3 unless already required by the planner for testability.
+- Broad recursive workspace crawling, full shell interpretation, and ecosystem-wide search remain out of scope.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| DOT-01 | tilde can map known dotfile paths to related tools using the shared metadata registry. | Use `getToolsByConfigPath()` and `getToolsByDotfilePath()` from `src/tools/registry.ts`; current tests prove exact and child-path matching. [VERIFIED: tests/unit/tool-metadata.test.ts] |
+| DOT-02 | tilde can parse common shell rc files for aliases, environment variables, plugin references, and PATH modifications. | Extend or replace `parseZshrc()` with a safe evidence parser that records names/kinds, not raw env values. [VERIFIED: src/capture/parser.ts] |
+| DOT-03 | tilde can look for tool config files in home and workspace context locations without mutating them. | Build on `scanInventory(homeDir)` and `InventoryEnvironmentSnapshot.homeDir`; use read-only `fs`/glob helpers and structured warnings. [VERIFIED: src/inventory/scan.ts] |
+| DOT-04 | Dotfile discovery output identifies unknown files separately from known tool-owned files. | The report should separate known matched findings from unknown file/finding buckets, matching D-04 and Phase 2's separate unmatched audit pattern. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+</phase_requirements>
+
+## Summary
+
+Phase 3 should add a `dotfiles` or `dotfileMap` section to the existing `InventoryReport` instead of creating a separate command or parallel scanner surface. App startup already owns inventory scanning and passes `InventoryScanState` into wizard and config-first flows; UI components are report-driven and should remain command-free. [VERIFIED: src/app.tsx] [VERIFIED: src/steps/inventory.tsx] [VERIFIED: src/modes/config-first.tsx]
+
+The implementation should be evidence-first. File summaries should describe scanned path, scope, matched tool ids, known/unknown/mixed state, warnings, and nested findings. Rc parsing should emit safe structured facts for alias names, function names, exported variable names and value kind, PATH edit kind, sourced path, and known init-hook matches. Raw env values should not be stored. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] [VERIFIED: AGENTS.md]
+
+**Primary recommendation:** Add a pure `src/inventory/dotfiles.ts` mapper plus report/summary integration in `src/inventory/report.ts`, `src/inventory/scan.ts`, and `src/inventory/summary.ts`; keep workspace scans bounded and test with temp directories and mocked registry metadata. [VERIFIED: src/inventory/scan.ts] [VERIFIED: tests/unit/inventory-scanner.test.ts]
+
+## Project Constraints (from AGENTS.md)
+
+- Runtime is Node.js >=20, TypeScript NodeNext, ESM-only, with `.js` import extensions in TypeScript source. [VERIFIED: AGENTS.md]
+- UI is Ink/React terminal UI; default output must remain concise and work in terminal workflows. [VERIFIED: AGENTS.md]
+- Platform target is macOS-first. [VERIFIED: AGENTS.md]
+- Discovery must be non-destructive by default and should read/report before writing or deleting. [VERIFIED: AGENTS.md]
+- Do not resolve or persist raw secrets; environment variables and secret references remain backend references. [VERIFIED: AGENTS.md]
+- External commands such as `brew`, `gh`, `op`, `vfox`, and `defaultbrowser` must be mocked in automated tests. [VERIFIED: AGENTS.md]
+- Source uses two-space indentation, single quotes, semicolons, strict TypeScript, and relative imports without path aliases. [VERIFIED: AGENTS.md]
+- GSD workflow says not to make repo edits outside GSD entry points; this research artifact is produced by the GSD research workflow. [VERIFIED: AGENTS.md]
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|--------------|----------------|-----------|
+| Metadata path discovery | CLI application source | Test suite | Registry helpers are pure source functions; scanner should consume them without UI ownership. [VERIFIED: src/tools/registry.ts] |
+| Home and dotfiles repo scanning | CLI application source | Local filesystem | Existing inventory scanner owns read-only local scanning and warning conversion. [VERIFIED: src/inventory/scan.ts] |
+| Workspace config scanning | CLI application source | Local filesystem | Config has `workspaceRoot`, contexts, and `dotfilesRepo`; scanner should read bounded paths only. [VERIFIED: src/config/schema.ts] |
+| Rc parsing | CLI application source | Test suite | Existing parser is pure and already used by wizard defaults; Phase 3 should keep parsing testable and side-effect free. [VERIFIED: src/capture/parser.ts] |
+| Concise output | Ink UI | Inventory summary helper | Wizard and config-first both render `summarizeInventory()`, preventing wording drift. [VERIFIED: src/inventory/summary.ts] |
+
+## Standard Stack
+
+### Core
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| Node.js `fs/promises` | Node >=20 | Read files, check paths, handle read errors. | Existing scanner already uses `access` for read-only evidence and converts failures to warnings. [VERIFIED: package.json] [VERIFIED: src/inventory/scan.ts] |
+| `fast-glob` | 3.3.3 | Bounded file discovery for home/workspace paths. | Already installed and used by `scanDotfiles()` with `onlyFiles`, `deep`, and `dot`. [VERIFIED: npm ls] [VERIFIED: src/capture/scanner.ts] |
+| `ignore` | 7.0.5 | Filter secret-like dotfiles before reading. | Existing `createCaptureFilter()` uses `ignore` with project secret patterns. [VERIFIED: npm ls] [VERIFIED: src/capture/filter.ts] |
+| Zod | 4.3.6 | Validate metadata and, if needed, structured report fixtures. | Metadata registry already uses Zod schemas and inferred types. [VERIFIED: npm ls] [VERIFIED: src/tools/metadata.ts] |
+
+### Supporting
+
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| Vitest | 4.1.2 | Unit/integration tests for scanners and Ink output. | Use for temp-dir scanner tests and inventory summary regression tests. [VERIFIED: npm ls] |
+| Ink / React | Ink 6.8.0 / React 19.2.4 | Terminal UI rendering. | Only for existing inventory/config-first surfaces; scanner code should not import Ink. [VERIFIED: npm ls] [VERIFIED: src/steps/inventory.tsx] |
+
+### Alternatives Considered
+
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Existing `fast-glob` | Hand-written recursive `readdir` | Avoid: phase explicitly forbids broad crawling; existing glob helper already supports bounded depth. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+| Safe regex/token parser | Full shell AST/interpreter | Avoid: locked decision D-06 excludes deep shell interpretation. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+| Existing `summarizeInventory()` | New verbose command | Avoid: D-13/D-15 require existing inventory summary surface by default. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+
+**Installation:**
+```bash
+# No new package install is recommended for Phase 3.
+```
+
+**Version verification:** `npm ls fast-glob ignore zod vitest ink react --depth=0` reported installed versions above. `npm view fast-glob` and `npm view ignore` confirmed current latest versions 3.3.3 and 7.0.5; broader registry lookups were intentionally stopped after the orchestration timeout. [VERIFIED: npm registry] [VERIFIED: npm ls]
+
+## Package Legitimacy Audit
+
+No external packages should be installed for Phase 3. Existing dependencies are already in `package.json` and `package-lock.json`; the planner should not add an install task unless a later implementation gap proves unavoidable. [VERIFIED: package.json]
+
+| Package | Registry | Age | Downloads | Source Repo | Verdict | Disposition |
+|---------|----------|-----|-----------|-------------|---------|-------------|
+| none | npm | — | — | — | — | No install recommended |
+
+**Packages removed due to [SLOP] verdict:** none
+**Packages flagged as suspicious [SUS]:** none for new installs
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```text
+App startup
+  -> scanInventory(homeDir?)
+      -> existing Homebrew/app/shell/core inventory scan
+      -> dotfile map scan
+          -> home rc-file candidates + metadata paths + dotfilesRepo + workspace allowlist
+          -> read files safely / skip missing or unreadable paths
+          -> registry path matching via getToolsByConfigPath/getToolsByDotfilePath
+          -> rc evidence parser for aliases, functions, exports, PATH edits, source lines, init hooks
+          -> known findings + unknown findings + warnings
+      -> InventoryReport with dotfileMap
+  -> InventoryScanState
+      -> InventoryStep summary
+      -> ConfigFirstMode summary
+      -> Phase 4 provenance consumes structured evidence later
+```
+
+### Recommended Project Structure
+
+```text
+src/inventory/
+├── dotfiles.ts       # pure-ish dotfile path mapper, rc parser, scan orchestration helpers
+├── report.ts         # DotfileMap report types added to InventoryReport
+├── scan.ts           # calls dotfile scan and attaches warnings
+└── summary.ts        # concise dotfile summary lines
+
+tests/unit/
+├── inventory-dotfiles.test.ts
+└── inventory-scanner.test.ts
+
+tests/integration/
+├── wizard-flow.test.tsx
+└── config-first.test.ts
+```
+
+### Pattern 1: Evidence-First File and Finding Shape
+
+**What:** Use file-level records with nested findings so one rc file can be mixed. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+**When to use:** Every scanned file, including unknown files and rc files with both known hooks and unknown aliases. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+**Example:**
+```typescript
+export type DotfileFindingKind =
+  | 'metadata-path'
+  | 'alias'
+  | 'function'
+  | 'export'
+  | 'path-edit'
+  | 'source'
+  | 'tool-init-hook'
+  | 'unknown';
+
+export interface DotfileFinding {
+  kind: DotfileFindingKind;
+  classification: 'known' | 'unknown' | 'ambiguous';
+  toolIds: string[];
+  safeDetails: Record<string, string | string[] | boolean>;
+  reason: string;
+}
+```
+
+### Pattern 2: Bounded Path Candidate Generation
+
+**What:** Generate candidates from metadata paths, fixed rc filenames, configured `dotfilesRepo`, and shallow workspace allowlists. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+**When to use:** DOT-01 and DOT-03 scanning. [VERIFIED: .planning/REQUIREMENTS.md]
+
+**Example:**
+```typescript
+const WORKSPACE_ALLOWLIST = [
+  '.config',
+  '.vscode',
+  '.github',
+  'package.json',
+  'tsconfig.json',
+] as const;
+```
+
+### Pattern 3: Safe Rc Value Classification
+
+**What:** For `export NAME=value`, store `NAME` and a value kind such as `literal`, `reference`, `command-derived`, or `secret-like`, not the raw value. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+**When to use:** All rc parsing. [VERIFIED: AGENTS.md]
+
+**Example:**
+```typescript
+function classifyEnvValue(raw: string): 'literal' | 'reference' | 'command-derived' | 'secret-like' {
+  if (/^(ghp_|sk-|AKIA|xox[bp]-|op:\/\/)/.test(raw)) return 'secret-like';
+  if (/\$\(|`/.test(raw)) return 'command-derived';
+  if (/\$[A-Za-z_][A-Za-z0-9_]*|\$\{[^}]+}/.test(raw)) return 'reference';
+  return 'literal';
+}
+```
+
+### Anti-Patterns to Avoid
+
+- **Putting scanner logic in Ink components:** `InventoryStep` currently renders supplied report data only; keep it that way. [VERIFIED: src/steps/inventory.tsx]
+- **Persisting env var values:** Existing `parseZshrc()` stores non-secret export values; Phase 3 must not repeat that for scanner output. [VERIFIED: src/capture/parser.ts] [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+- **Broad recursive workspace crawling:** D-10/D-11 explicitly require shallow allowlists and deterministic traversal. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+- **Treating unknown files as failures:** Unknown files/findings are normal evidence and must be reported separately. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Metadata matching | Per-tool path switch statements | `getToolsByConfigPath()` / `getToolsByDotfilePath()` | Existing pure helpers already cover exact and child paths. [VERIFIED: src/tools/registry.ts] |
+| Secret filtering | New scattered regexes only | Existing `defaultSecretPatterns` plus value-kind classification | Current capture filter already centralizes secret-pattern filtering for dotfiles. [VERIFIED: src/capture/filter.ts] |
+| UI summary formatting | Separate wizard/config-first text | `summarizeInventory()` | Phase 2 centralized summary output to avoid drift. [VERIFIED: .planning/phases/02-machine-inventory-scanner/02-05-SUMMARY.md] |
+| Shell execution model | Shell interpreter or AST execution | Bounded line parser | D-06 excludes arbitrary execution and full control-flow analysis. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+
+**Key insight:** This phase is a discovery evidence layer, not a shell runtime or final provenance classifier. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+## Common Pitfalls
+
+### Pitfall 1: Registry Metadata Is Too Sparse
+**What goes wrong:** DOT-01 appears implemented but maps very few files because current metadata only includes config/dotfile paths for Neovim, Zed, and Obsidian. [VERIFIED: src/plugins/first-party/neovim/metadata.ts] [VERIFIED: src/plugins/first-party/zed/metadata.ts] [VERIFIED: src/tools/note-taking-metadata.ts]
+**How to avoid:** Plan metadata additions for existing first-party tools where known config paths are in scope, then test lookups. [VERIFIED: tests/unit/tool-metadata.test.ts]
+
+### Pitfall 2: Secret Values Leak Through Rc Parsing
+**What goes wrong:** The existing parser stores export values unless they match a prefix denylist. [VERIFIED: src/capture/parser.ts]
+**How to avoid:** Store variable names and value kinds only; add tests for `GH_TOKEN`, `op://`, command substitution, and `$PATH` references. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+### Pitfall 3: Workspace Scan Becomes Unbounded
+**What goes wrong:** A recursive glob over `workspaceRoot` can scan large repos, dependency folders, or secret files. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+**How to avoid:** Use allowlisted root files/directories, low `deep`, `onlyFiles: true`, and skipped/warning findings. [VERIFIED: src/capture/scanner.ts]
+
+### Pitfall 4: Summary Overwhelms the Terminal
+**What goes wrong:** Every finding is dumped into Ink output. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+**How to avoid:** Add only count/group lines to `summarizeInventory()`; keep detailed findings in `InventoryReport`. [VERIFIED: src/inventory/summary.ts]
+
+## Code Examples
+
+### Registry Path Matching
+```typescript
+const configMatches = getToolsByConfigPath(candidate.tildePath);
+const dotfileMatches = getToolsByDotfilePath(candidate.tildePath);
+const toolIds = [...new Set([...configMatches, ...dotfileMatches].map(tool => tool.id))];
+```
+
+### Warning Instead of Throwing
+```typescript
+try {
+  const content = await readFile(path, 'utf-8');
+  return parseDotfileContent(path, content);
+} catch {
+  warnings.push({
+    id: `dotfiles:unreadable:${path}`,
+    source: 'dotfiles',
+    severity: 'warning',
+    message: `Dotfile ${path} could not be read; discovery skipped it.`,
+  });
+  return undefined;
+}
+```
+
+### Summary Lines
+```typescript
+if (report.dotfiles) {
+  lines.push(`Dotfiles: ${report.dotfiles.knownFilesCount} known, ${report.dotfiles.unknownFilesCount} unknown`);
+  if (report.dotfiles.unknownFindingsCount > 0) {
+    lines.push(`Dotfile findings: ${report.dotfiles.unknownFindingsCount} unknown`);
+  }
+}
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| `EnvironmentCaptureReport` as primary scanner boundary | `InventoryReport` and `InventoryScanState` | Phase 2 | Phase 3 should extend inventory, not revive environment capture as the main API. [VERIFIED: .planning/phases/02-machine-inventory-scanner/02-03-SUMMARY.md] |
+| Parser stores non-secret export values | Parser should store env name and value kind only | Phase 3 decision | Prevents secret leakage and aligns with AGENTS security constraints. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+| Dotfiles scanned as raw path list | Dotfiles map should classify known, unknown, and mixed findings | Phase 3 decision | Enables Phase 4 provenance without final labels. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+
+**Deprecated/outdated:**
+- Keeping `src/capture/scanner.ts` as the primary scanner boundary is outdated after Phase 2; use it only as a helper/reference. [VERIFIED: .planning/phases/02-machine-inventory-scanner/02-CONTEXT.md]
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | Known tool init hooks can start with a small curated set such as `direnv hook`, `vfox activate`, and editor/tool-specific source lines. [ASSUMED] | Architecture Patterns | Planner may need user confirmation or codebase-specific hook list before implementation. |
+| A2 | Workspace root scan should include common root files like `package.json` and `tsconfig.json` only if mapped through metadata or clearly useful for context. [ASSUMED] | Architecture Patterns | Planner could over-scan unless it keeps the allowlist conservative. |
+
+## Open Questions
+
+1. **Should `dotfileMap` live directly on `InventoryReport` or under `environment`?**
+   - What we know: `InventoryReport` already separates tools, Homebrew audit, warnings, and environment snapshot. [VERIFIED: src/inventory/report.ts]
+   - What's unclear: Whether planners prefer a top-level `dotfiles` section for Phase 4 consumption.
+   - Recommendation: Use a top-level `dotfiles` section because it is not just environment defaults; it is provenance evidence. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+
+2. **Which metadata rows should gain config paths in Plan 03-01?**
+   - What we know: Current paths are sparse. [VERIFIED: src/plugins/first-party/neovim/metadata.ts] [VERIFIED: src/plugins/first-party/zed/metadata.ts] [VERIFIED: src/tools/note-taking-metadata.ts]
+   - What's unclear: Exact macOS config paths for every first-party tool were not externally verified before the orchestrator timeout.
+   - Recommendation: Only add paths already known from code/docs or covered by tests; do not invent broad rows. [VERIFIED: AGENTS.md]
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|-------------|-----------|---------|----------|
+| Node.js | Build/test/runtime | yes | >=20 required by `package.json` | none |
+| npm | Scripts and installed dependency checks | yes | package-lock present | none |
+| `fast-glob` | File scanning | yes | 3.3.3 | Node `fs.readdir` only for fixed candidate lists |
+| `ignore` | Secret/dotfile filtering | yes | 7.0.5 | Existing `defaultSecretPatterns` direct matching |
+| Vitest | Validation | yes | 4.1.2 | none |
+
+**Missing dependencies with no fallback:** none identified.
+
+**Missing dependencies with fallback:** none for planned implementation.
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | Vitest 4.1.2 |
+| Config file | `vitest.config.ts`, `vitest.integration.config.ts`, `vitest.contract.config.ts` |
+| Quick run command | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` |
+| Full suite command | `npm run lint && npm run build && npm test && npm run test:integration` |
+
+### Phase Requirements -> Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|--------------|
+| DOT-01 | Metadata-declared config/dotfile paths map to tool ids. | unit | `npm run test -- tests/unit/tool-metadata.test.ts tests/unit/inventory-dotfiles.test.ts` | partial; Wave 0 for new file |
+| DOT-02 | Rc parser emits aliases, function names, env var names/value kinds, PATH edits, source lines, and known hooks without raw secret values. | unit | `npm run test -- tests/unit/inventory-dotfiles.test.ts` | no; Wave 0 |
+| DOT-03 | Home, dotfiles repo, and shallow workspace paths are scanned read-only with skipped/warning findings. | unit | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` | no; Wave 0 |
+| DOT-04 | Unknown files/findings are separated from known tool-owned findings and not errors. | unit/integration | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/integration/wizard-flow.test.tsx -t inventory` | partial; Wave 0 for unit |
+
+### Sampling Rate
+
+- **Per task commit:** targeted unit or integration command for touched area.
+- **Per wave merge:** `npm run lint && npm run build && npm test`.
+- **Phase gate:** `npm run lint && npm run build && npm test && npm run test:integration`.
+
+### Wave 0 Gaps
+
+- [ ] `tests/unit/inventory-dotfiles.test.ts` - covers DOT-01, DOT-02, DOT-03, DOT-04.
+- [ ] Extend `tests/unit/inventory-scanner.test.ts` - proves `scanInventory()` attaches dotfile map and warning data.
+- [ ] Extend `tests/integration/wizard-flow.test.tsx` and `tests/integration/config-first.test.ts` - proves concise dotfile summary appears in both inventory surfaces.
+
+## Security Domain
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|------------------|
+| V2 Authentication | no | No auth boundary in this phase. [VERIFIED: .planning/ROADMAP.md] |
+| V3 Session Management | no | No session state in this CLI phase. [VERIFIED: .planning/codebase/ARCHITECTURE.md] |
+| V4 Access Control | no | Local CLI read-only scan; no user/role model. [VERIFIED: .planning/codebase/ARCHITECTURE.md] |
+| V5 Input Validation | yes | Validate metadata with Zod and normalize bounded paths before matching. [VERIFIED: src/tools/metadata.ts] |
+| V6 Cryptography | no | Do not implement crypto; do not resolve secrets. [VERIFIED: AGENTS.md] |
+
+### Known Threat Patterns for Local Dotfile Scanning
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Secret disclosure from `.env` or rc exports | Information Disclosure | Filter secret dotfiles and store env names/value kinds only. [VERIFIED: src/capture/filter.ts] [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+| Symlink or broad traversal causing unexpected reads | Information Disclosure | Use explicit candidate paths, shallow allowlists, low depth, and skipped findings. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+| Parse failure blocking setup | Denial of Service | Convert missing/unreadable/parse failures into warnings. [VERIFIED: src/inventory/scan.ts] |
+| Shell command execution during parsing | Elevation of Privilege | Never execute rc content; parse text only. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+
+## Sources
+
+### Primary (HIGH confidence)
+- `.planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md` - locked Phase 3 decisions.
+- `.planning/REQUIREMENTS.md` - DOT-01 through DOT-04 requirements.
+- `.planning/ROADMAP.md` - Phase 3 goal, success criteria, and plan slices.
+- `.planning/STATE.md` - Phase 2 decisions and current project history.
+- `.planning/phases/02-machine-inventory-scanner/*-SUMMARY.md` - implemented inventory seams.
+- `AGENTS.md` - project constraints.
+- `src/tools/metadata.ts`, `src/tools/registry.ts` - metadata schema and path helpers.
+- `src/inventory/report.ts`, `src/inventory/scan.ts`, `src/inventory/summary.ts` - inventory report, scanner, summary seams.
+- `src/capture/scanner.ts`, `src/capture/parser.ts`, `src/capture/filter.ts` - prior dotfile and rc scan helpers.
+- `tests/unit/tool-metadata.test.ts`, `tests/unit/inventory-scanner.test.ts`, `tests/integration/wizard-flow.test.tsx`, `tests/integration/config-first.test.ts` - existing validation patterns.
+
+### Secondary (MEDIUM confidence)
+- `npm ls` and selected `npm view` checks - existing package versions and `fast-glob`/`ignore` current versions.
+
+### Tertiary (LOW confidence)
+- Small initial known-hook list for shell rc parsing; planner should keep this conservative or require user confirmation.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH - existing package versions and code usage verified locally.
+- Architecture: HIGH - Phase 2 implementation summaries and source code define the integration seam.
+- Pitfalls: HIGH for codebase/security pitfalls; MEDIUM for shell-hook coverage.
+
+**Research date:** 2026-06-19
+**Valid until:** 2026-07-19 for codebase patterns; shell hook assumptions should be revisited during planning.

--- a/.planning/phases/03-dotfiles-discovery-map/03-REVIEW.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-REVIEW.md
@@ -1,0 +1,131 @@
+---
+phase: 03-dotfiles-discovery-map
+reviewed: 2026-06-19T22:43:31Z
+depth: standard
+files_reviewed: 8
+files_reviewed_list:
+  - src/inventory/dotfiles.ts
+  - src/inventory/report.ts
+  - src/inventory/scan.ts
+  - src/inventory/summary.ts
+  - tests/unit/inventory-dotfiles.test.ts
+  - tests/unit/inventory-scanner.test.ts
+  - tests/integration/wizard-flow.test.tsx
+  - tests/integration/config-first.test.ts
+findings:
+  critical: 4
+  warning: 1
+  info: 0
+  total: 5
+status: issues_found
+---
+
+# Phase 03: Code Review Report
+
+**Reviewed:** 2026-06-19T22:43:31Z
+**Depth:** standard
+**Files Reviewed:** 8
+**Status:** issues_found
+
+## Summary
+
+Reviewed the Phase 03 dotfile map, inventory report integration, summary output, and unit/integration tests. The implementation adds the intended scanner surface, but several privacy and robustness requirements are not met: ignored secret files can still be scanned and read, warning text leaks absolute paths into default terminal output, collection errors can fail the whole inventory scan, and source parsing can persist arbitrary trailing shell text.
+
+## Narrative Findings (AI reviewer)
+
+## Critical Issues
+
+### CR-01: BLOCKER - Secret-pattern files can still be scanned and read
+
+**File:** `src/inventory/dotfiles.ts:278`
+**Issue:** The scanner filters home-root dotfiles through `filterDotfiles()`, but metadata directories, dotfiles repo candidates, and workspace shallow candidates bypass the secret-pattern filter. `collectMetadataCandidates()` recursively adds every file under metadata directories at lines 278-285, `collectRootAndShallowCandidates()` adds repo files including root dotfiles at lines 321-328, and `collectWorkspaceCandidates()` adds `.config/*/*` paths at lines 338-344. Every candidate is then read at lines 378-381 before rc parsing is even needed. That means `.env`, `.env.*`, `*.key`, `*.pem`, logs, and other excluded files under `~/.config/<tool>`, a dotfiles repo, or a workspace `.config` directory are read and recorded as file evidence, violating the phase threat model and the project security rule to avoid raw secret exposure.
+**Fix:**
+```ts
+function shouldScanCandidate(filePath: string, filter = createCaptureFilter()): boolean {
+  const relativeName = filePath.split(sep).join('/');
+  return !filter.ignores(basename(filePath)) && !filter.ignores(relativeName);
+}
+
+// Apply before adding every metadata/repo/workspace candidate.
+if (!shouldScanCandidate(filePath)) {
+  continue;
+}
+
+// Only read rc files; for non-rc files, lstat/access is enough to create path evidence.
+const findings = createMetadataFindings(candidate.queryPath);
+if (isRcFile(candidate.path)) {
+  const content = await readFile(candidate.path, 'utf-8');
+  findings.push(...parseShellRcFindings(candidate.path, content));
+}
+```
+Add regression tests with `.env`, `.env.local`, `id_rsa.key`, and `debug.log` under metadata, dotfiles repo, and workspace allowlist directories.
+
+### CR-02: BLOCKER - Dotfile warnings leak absolute local paths in default terminal output
+
+**File:** `src/inventory/dotfiles.ts:363`
+**Issue:** Symlink and unreadable warnings include the full candidate path (`${candidate.path}`) at lines 363 and 382. `summarizeInventory()` then prints every warning message by default at lines 25-29 in `src/inventory/summary.ts`, and both wizard/config-first surfaces render those summary lines. A skipped symlink such as `/Users/alice/.ssh/config` or an unreadable private rc file will therefore be displayed in the default UI, contradicting the phase requirement that default output stay aggregate and not dump detailed paths.
+**Fix:**
+```ts
+const warning = pushDotfileWarning(warnings, 'Skipped symlink dotfile candidate.');
+return {
+  path: candidate.path,
+  scope: candidate.scope,
+  state: 'skipped',
+  toolIds: [],
+  findings: [],
+  warningIds: [warning.id],
+};
+```
+Keep the detailed path only in structured audit data if it is intentionally part of the non-default report, or store a redacted path such as `~/<basename>`. Add wizard and config-first tests where a dotfile warning contains a private absolute path and assert the rendered inventory block omits it.
+
+### CR-03: BLOCKER - Dotfile filesystem errors can reject the entire inventory scan
+
+**File:** `src/inventory/dotfiles.ts:263`
+**Issue:** The phase requires unreadable paths and malformed local filesystem state to become warnings/skips, but collection-time errors are not contained. `statIfExists()` rethrows anything except `ENOENT`/`ENOTDIR` at lines 697-705, and callers in metadata/root/workspace collection do not catch it. The same is true for `fast-glob` calls at lines 278, 301, 321, and 338. Because `scanInventory()` awaits `scanDotfileMap()` directly at `src/inventory/scan.ts:58`, an `EACCES`, `EPERM`, or malformed cwd from a local candidate can fail the whole inventory scan instead of returning a usable report with dotfile warnings.
+**Fix:**
+```ts
+async function collectSafely(
+  warnings: InventoryWarning[],
+  scope: DotfileScanScope,
+  operation: () => Promise<DotfileCandidate[]>
+): Promise<DotfileCandidate[]> {
+  try {
+    return await operation();
+  } catch {
+    pushDotfileWarning(warnings, `Skipped ${scope} dotfile scan segment.`);
+    return [];
+  }
+}
+```
+Thread `warnings` into candidate collection, catch per scan segment, and add tests that mock `lstat`/`fast-glob` to throw `EACCES` and verify `scanDotfileMap()` resolves with a warning.
+
+### CR-04: BLOCKER - Source parsing can persist arbitrary trailing shell text
+
+**File:** `src/inventory/dotfiles.ts:202`
+**Issue:** The source regex captures everything after `source` or `.` through the end of the line at lines 202-204. `createSourceFinding()` then stores that full target whenever it is not command substitution at lines 571-582. Lines such as `source ~/.aliases; export TOKEN=plainsecret`, `. "$HOME/.profile" && echo "$SECRET"`, or `source ~/.private # token hint` can persist command text, env references, comments, or secret-looking trailing content in `safeDetails.target`. This violates the plan boundary to store only normalized source targets or safe kinds, not arbitrary shell text.
+**Fix:**
+```ts
+function parseSourceTarget(rawTarget: string): { sourceKind: 'literal' | 'reference' | 'command-derived'; target?: string } {
+  const stripped = stripInlineComment(rawTarget).trim();
+  if (/[;&|<>]/.test(stripped) || /\$\(|`/.test(stripped)) {
+    return { sourceKind: 'command-derived' };
+  }
+  const target = stripped.replace(/^(['"])(.*)\1$/, '$2');
+  return { sourceKind: classifySourceTarget(target), target };
+}
+```
+Add tests for semicolon, `&&`, inline comments, and command substitutions to ensure serialized findings do not contain trailing shell commands or secret-like substrings.
+
+## Warnings
+
+### WR-01: WARNING - Known hook matching creates false known-tool evidence from arbitrary text
+
+**File:** `src/inventory/dotfiles.ts:531`
+**Issue:** `knownHookForLine()` checks for `direnv hook`, `vfox activate`, `op signin`, and `brew shellenv` anywhere in a non-comment line. Because `parseKnownHook()` runs before alias/export/source parsing, harmless lines like `alias explain='echo run direnv hook zsh'` or `echo "brew shellenv"` become high-confidence known `tool-init-hook` findings. That can mislead downstream provenance by turning documentation or aliases into trusted tool initialization evidence.
+**Fix:** Restrict hook recognition to actual shell initialization forms, such as `eval "$(direnv hook zsh)"`, `eval "$(vfox activate zsh)"`, `eval "$(op signin)"`, or `eval "$(/opt/homebrew/bin/brew shellenv)"`, with anchored patterns. Add negative tests for aliases and echo lines containing the same words.
+
+---
+
+_Reviewed: 2026-06-19T22:43:31Z_
+_Reviewer: the agent (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
@@ -21,16 +21,31 @@ created: 2026-06-19
 | **Config file** | `vitest.config.ts`, `vitest.integration.config.ts`, `vitest.contract.config.ts` |
 | **Quick run command** | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` |
 | **Full suite command** | `npm run lint && npm run build && npm test && npm run test:integration` |
-| **Estimated runtime** | ~120 seconds |
+| **Targeted task command latency** | < 30 seconds |
+| **Full suite estimated runtime** | ~120 seconds; wave/phase gate only |
 
 ---
 
 ## Sampling Rate
 
-- **After every task commit:** Run `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts`
+- **After every task commit:** Run the task-specific targeted command from the Per-Task Verification Map below; each task-level command must complete in under 30 seconds or be narrowed before continuing.
 - **After every plan wave:** Run `npm run lint && npm run build && npm test`
 - **Before `$gsd-verify-work`:** Full suite must be green
-- **Max feedback latency:** 120 seconds
+- **Max task feedback latency:** < 30 seconds
+- **Full-suite latency:** ~120 seconds, reserved for wave and phase gates
+
+---
+
+## Targeted Task Commands
+
+| Task ID | Targeted Command | Expected Latency | Gate |
+|---------|------------------|------------------|------|
+| 03-01-01 | `npm run test -- tests/unit/tool-metadata.test.ts tests/unit/inventory-dotfiles.test.ts` | < 30 seconds | task |
+| 03-01-02 | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` | < 30 seconds | task |
+| 03-02-01 | `npm run test -- tests/unit/inventory-dotfiles.test.ts` | < 30 seconds | task |
+| 03-02-02 | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/integration/wizard-flow.test.tsx -t inventory` | < 30 seconds | task |
+
+Full `lint`, `build`, `npm test`, and `test:integration` runs remain required at wave or phase gates, not as the primary task feedback loop.
 
 ---
 
@@ -68,7 +83,8 @@ All phase behaviors have automated verification.
 - [x] Sampling continuity: no 3 consecutive tasks without automated verify
 - [x] Wave 0 covers all MISSING references
 - [x] No watch-mode flags
-- [x] Feedback latency < 120s
+- [x] Task feedback latency < 30s
+- [x] Full suite reserved for wave/phase gates
 - [x] `nyquist_compliant: true` set in frontmatter
 
 **Approval:** approved 2026-06-19

--- a/.planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-VALIDATION.md
@@ -1,0 +1,74 @@
+---
+phase: 03
+slug: dotfiles-discovery-map
+status: draft
+nyquist_compliant: true
+wave_0_complete: false
+created: 2026-06-19
+---
+
+# Phase 03 - Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Vitest 4.1.2 |
+| **Config file** | `vitest.config.ts`, `vitest.integration.config.ts`, `vitest.contract.config.ts` |
+| **Quick run command** | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` |
+| **Full suite command** | `npm run lint && npm run build && npm test && npm run test:integration` |
+| **Estimated runtime** | ~120 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts`
+- **After every plan wave:** Run `npm run lint && npm run build && npm test`
+- **Before `$gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** 120 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 03-01-01 | 01 | 1 | DOT-01 | T-03-01 | Metadata path matching never reads outside explicit candidates | unit | `npm run test -- tests/unit/tool-metadata.test.ts tests/unit/inventory-dotfiles.test.ts` | W0 | pending |
+| 03-01-02 | 01 | 1 | DOT-03 | T-03-02 | Home, dotfiles repo, and workspace scans remain read-only and bounded | unit | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` | W0 | pending |
+| 03-02-01 | 02 | 2 | DOT-02 | T-03-03 | Rc parsing records env names and value kinds without raw values | unit | `npm run test -- tests/unit/inventory-dotfiles.test.ts` | W0 | pending |
+| 03-02-02 | 02 | 2 | DOT-04 | T-03-04 | Unknown files and findings are reported separately without error state | unit/integration | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/integration/wizard-flow.test.tsx -t inventory` | W0 | pending |
+
+*Status: pending, green, red, flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `tests/unit/inventory-dotfiles.test.ts` - covers DOT-01, DOT-02, DOT-03, DOT-04.
+- [ ] Extend `tests/unit/inventory-scanner.test.ts` - proves `scanInventory()` attaches dotfile map and warning data.
+- [ ] Extend `tests/integration/wizard-flow.test.tsx` - proves concise dotfile summary appears in the inventory wizard surface.
+- [ ] Extend `tests/integration/config-first.test.ts` - proves concise dotfile summary appears in config-first output.
+
+---
+
+## Manual-Only Verifications
+
+All phase behaviors have automated verification.
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have automated verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references
+- [x] No watch-mode flags
+- [x] Feedback latency < 120s
+- [x] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** approved 2026-06-19

--- a/.planning/phases/03-dotfiles-discovery-map/03-VERIFICATION.md
+++ b/.planning/phases/03-dotfiles-discovery-map/03-VERIFICATION.md
@@ -1,0 +1,109 @@
+---
+phase: 03-dotfiles-discovery-map
+verified: 2026-06-19T22:54:27Z
+status: passed
+score: 8/8 must-haves verified
+overrides_applied: 0
+---
+
+# Phase 3: Dotfiles Discovery Map Verification Report
+
+**Phase Goal:** User can see which known dotfiles and shell rc-file contents map to tools, distinguish unknown local customization, and trust what tilde understands before it changes anything.
+**Verified:** 2026-06-19T22:54:27Z
+**Status:** passed
+**Re-verification:** No - initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Known dotfile paths are matched through registry metadata. | VERIFIED | `src/inventory/dotfiles.ts:458-485` calls `getToolsByConfigPath()` and `getToolsByDotfilePath()` and emits known `metadata-path` findings; `tests/unit/inventory-dotfiles.test.ts:66-129` verifies Neovim and Obsidian metadata matches. |
+| 2 | Shell rc parsing surfaces aliases, env vars, plugin references, PATH edits, source statements, and known hooks without raw values. | VERIFIED | `parseShellRcFindings()` in `src/inventory/dotfiles.ts:153-210`, export classification at `212-230`, anchored hook matching at `566-584`, and source sanitization at `606-646`; tests at `tests/unit/inventory-dotfiles.test.ts:196-310` assert safe details and raw-value absence. |
+| 3 | Home, dotfiles repo, and workspace candidates are scanned read-only through bounded allowlists. | VERIFIED | Candidate collection uses low-depth `fast-glob`, explicit patterns, `followSymbolicLinks: false`, and filter checks in `src/inventory/dotfiles.ts:233-386`; tests at `tests/unit/inventory-dotfiles.test.ts:131-157` verify home, repo, workspace, excluded secret files, and no deep nested scan. |
+| 4 | Unknown files and rc findings are represented separately and are not errors. | VERIFIED | Unknown path findings are normal `DotfileFinding` records in `src/inventory/dotfiles.ts:433-444`; file states/counts are derived at `684-722`; tests at `tests/unit/inventory-dotfiles.test.ts:159-194` and `312-336` verify unknown/skipped behavior and separate known/unknown rc counts. |
+| 5 | `scanInventory()` always returns `InventoryReport.dotfiles`. | VERIFIED | `InventoryReport.dotfiles` and empty defaults exist in `src/inventory/report.ts:64-99`; `scanInventory()` populates it in `src/inventory/scan.ts:58-63`; scanner test verifies attached map at `tests/unit/inventory-scanner.test.ts:356-382`. |
+| 6 | Concise inventory output includes dotfile and rc finding counts without detailed paths or raw values. | VERIFIED | `summarizeInventory()` reads `report.dotfiles.counts` in `src/inventory/summary.ts:16-23`; tests verify no unknown path leakage in `tests/unit/inventory-scanner.test.ts:380-381` and no rc detail leakage in integration tests. |
+| 7 | Wizard and config-first surfaces share the same dotfile summary text. | VERIFIED | Both surfaces consume `summarizeInventory()` output; integration tests assert shared `Dotfiles:` and `Dotfile findings:` lines in `tests/integration/wizard-flow.test.tsx:381-413` and `tests/integration/config-first.test.ts:163-193`. |
+| 8 | Review blockers from `03-REVIEW.md` are fixed by commit `00918d1`. | VERIFIED | `00918d1` is `HEAD` and modifies `src/inventory/dotfiles.ts` plus regression tests. CR-01 fixed by `shouldScanCandidate()` filtering at `776-783`; CR-02 fixed by generic warning messages at `397-425`; CR-03 fixed by `collectSafely()` at `730-741`; CR-04 fixed by `parseSourceTarget()` at `628-646`; WR-01 fixed by anchored `knownHookForLine()` at `566-584`. |
+
+**Score:** 8/8 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/inventory/dotfiles.ts` | Dotfile map, candidate discovery, metadata matching, rc parser, safe summaries | VERIFIED | Substantive exported scanner/parser functions and safe helper logic present; GSD artifact check passed. |
+| `src/inventory/report.ts` | `InventoryReport.dotfiles` and `dotfiles` warning source | VERIFIED | Field and empty default exist at `64-99`; warning source includes `dotfiles` at `12`. |
+| `src/inventory/scan.ts` | `scanInventory()` integration and scan options | VERIFIED | `InventoryScanOptions` includes `dotfilesRepo`/`workspaceRoots`; `scanDotfileMap()` is called with shared warnings. |
+| `src/inventory/summary.ts` | Concise dotfile and rc findings summary | VERIFIED | Emits aggregate `Dotfiles:` and conditional `Dotfile findings:` lines only. |
+| `tests/unit/inventory-dotfiles.test.ts` | DOT-01, DOT-02, DOT-03, DOT-04 coverage | VERIFIED | Covers metadata matching, allowlists, secret filters, unknowns, rc parsing, safe source parsing, hook matching. |
+| `tests/unit/inventory-scanner.test.ts` | Scanner integration and summary coverage | VERIFIED | Verifies `scanInventory()` attaches dotfile map and summary hides detailed unknown paths. |
+| `tests/integration/wizard-flow.test.tsx` | Wizard summary regression | VERIFIED | Verifies shared aggregate text and no rc detail/path leakage. |
+| `tests/integration/config-first.test.ts` | Config-first summary regression | VERIFIED | Verifies same aggregate text and no rc detail/path leakage. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `src/inventory/scan.ts` | `src/inventory/dotfiles.ts` | `scanDotfileMap()` in `scanInventory()` | WIRED | GSD key-link check passed; code at `src/inventory/scan.ts:58-63`. |
+| `src/inventory/dotfiles.ts` | `src/tools/registry.ts` | `getToolsByConfigPath()` / `getToolsByDotfilePath()` | WIRED | GSD key-link check passed; code at `src/inventory/dotfiles.ts:458-465`. |
+| `src/inventory/summary.ts` | `InventoryReport.dotfiles` | summary counts | WIRED | Manual check confirms `report.dotfiles.counts` at `src/inventory/summary.ts:16-23`; GSD helper false-negatived on escaped pattern. |
+| `src/inventory/dotfiles.ts` | `src/inventory/summary.ts` | rc finding counts | WIRED | `knownFindingsCount` / `unknownFindingsCount` are built in `dotfiles.ts` and rendered in `summary.ts`; GSD key-link check passed. |
+| Integration tests | shared summary output | `Dotfiles:` / `Dotfile findings:` assertions | WIRED | Wizard and config-first assertions both present and passing. |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|----------|---------------|--------|--------------------|--------|
+| `src/inventory/summary.ts` | `report.dotfiles.counts` | `scanInventory()` -> `scanDotfileMap()` -> filesystem/registry-derived files and findings | Yes | VERIFIED |
+| `src/inventory/dotfiles.ts` | `files`, `tools`, `counts`, `warningIds` | Bounded candidate collection + metadata registry + rc parser | Yes | VERIFIED |
+| Wizard/config-first inventory blocks | summary lines | `summarizeInventory(report)` | Yes | VERIFIED |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Targeted dotfile scanner/unit behavior | `npm run test -- tests/unit/inventory-dotfiles.test.ts tests/unit/inventory-scanner.test.ts` | 2 files passed, 15 tests passed | PASS |
+| Wizard/config-first shared inventory output | `npm run test:integration -- tests/integration/wizard-flow.test.tsx tests/integration/config-first.test.ts -t inventory` | 2 files passed; 10 tests passed, 17 skipped | PASS |
+| TypeScript build | `npm run build` | `tsc && tsc -p tsconfig.bin.json` exited 0 | PASS |
+| Lint | `npm run lint` | ESLint exited 0 | PASS |
+| Full unit suite | `npm test` | 28 files passed, 272 tests passed | PASS |
+
+### Probe Execution
+
+| Probe | Command | Result | Status |
+|-------|---------|--------|--------|
+| N/A | N/A | Step 7c skipped: no phase-declared or conventional probe scripts for this feature phase. | SKIPPED |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| DOT-01 | `03-01-PLAN.md` | Map known dotfile paths to related tools using shared metadata registry. | SATISFIED | Registry helper calls and metadata path findings in `src/inventory/dotfiles.ts:458-485`; tests verify known Neovim/Obsidian matches. |
+| DOT-02 | `03-02-PLAN.md` | Parse common shell rc files for aliases, env vars, plugin references, and PATH modifications. | SATISFIED | Parser covers alias/function/export/PATH/source/hooks in `src/inventory/dotfiles.ts:153-210`; tests verify safe structured output. |
+| DOT-03 | `03-01-PLAN.md` | Look for tool config files in home and workspace context locations without mutating them. | SATISFIED | Scanner only uses `lstat`, `readFile`, and `fast-glob` with bounded patterns; tests cover workspace known config discovery and excluded deep/secret files. |
+| DOT-04 | `03-01-PLAN.md`, `03-02-PLAN.md` | Identify unknown files separately from known tool-owned files. | SATISFIED | Unknown path and rc findings are separate classifications/counts; tests verify unknown file and rc finding separation. |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `src/inventory/dotfiles.ts` | 131, 154, 271, 459 | empty accumulator defaults | Info | Normal collection initialization, populated by scanner/parser before return. |
+| `src/inventory/scan.ts` | 152, 166, 175, 187, 196 | soft-failure empty/null returns | Info | Intentional inventory fail-soft behavior inherited from Phase 2. |
+
+No blocker debt markers (`TBD`, `FIXME`, `XXX`) were found in the phase-modified files.
+
+### Human Verification Required
+
+None. The phase deliverables are scanner/report/terminal-text behavior, and the shared wizard/config-first output is covered by integration tests.
+
+### Gaps Summary
+
+No blocking gaps found. The phase goal is achieved in the codebase, and the review blockers are closed by `00918d1`.
+
+---
+
+_Verified: 2026-06-19T22:54:27Z_
+_Verifier: the agent (gsd-verifier)_

--- a/src/inventory/dotfiles.ts
+++ b/src/inventory/dotfiles.ts
@@ -1,0 +1,599 @@
+import { lstat, open } from 'node:fs/promises';
+import { relative, resolve, sep } from 'node:path';
+import fg from 'fast-glob';
+import { createCaptureFilter, filterDotfiles } from '../capture/filter.js';
+import { allToolMetadata, getToolsByConfigPath, getToolsByDotfilePath } from '../tools/registry.js';
+import type { ToolMetadata } from '../tools/metadata.js';
+import type { InventoryWarning } from './report.js';
+
+export type DotfileScanScope = 'home' | 'dotfiles-repo' | 'workspace';
+
+export type DotfileFindingKind =
+  | 'metadata-path'
+  | 'alias'
+  | 'function'
+  | 'export'
+  | 'path-edit'
+  | 'source'
+  | 'tool-init-hook'
+  | 'unknown';
+
+export type DotfileFindingClassification = 'known' | 'unknown' | 'ambiguous';
+
+export type DotfileFileState = 'known' | 'unknown' | 'mixed' | 'skipped';
+
+export type DotfileFindingConfidence = 'high' | 'medium' | 'low';
+
+export type RcExportValueKind = 'empty' | 'literal' | 'reference' | 'command-derived' | 'secret-like';
+
+export interface DotfileFinding {
+  kind: DotfileFindingKind;
+  classification: DotfileFindingClassification;
+  toolIds: string[];
+  reason: string;
+  confidence: DotfileFindingConfidence;
+  safeDetails: Record<string, string | string[] | boolean | number>;
+}
+
+export interface DotfileFileSummary {
+  path: string;
+  scope: DotfileScanScope;
+  state: DotfileFileState;
+  toolIds: string[];
+  findings: DotfileFinding[];
+  warningIds: string[];
+}
+
+export interface DotfileToolSummary {
+  toolId: string;
+  label: string;
+  category: string;
+  knownFileCount: number;
+  findingCount: number;
+  paths: string[];
+}
+
+export interface DotfileMap {
+  homeDir: string;
+  files: DotfileFileSummary[];
+  tools: DotfileToolSummary[];
+  counts: {
+    totalFiles: number;
+    knownFiles: number;
+    unknownFiles: number;
+    mixedFiles: number;
+    skippedFiles: number;
+    warnings: number;
+  };
+  warningIds: string[];
+}
+
+export interface DotfileScanOptions {
+  homeDir?: string;
+  dotfilesRepo?: string;
+  workspaceRoots?: string[];
+  warnings?: InventoryWarning[];
+}
+
+interface DotfileCandidate {
+  path: string;
+  scope: DotfileScanScope;
+  queryPath: string;
+}
+
+const HOME_RC_CANDIDATES = [
+  '.zshrc',
+  '.zprofile',
+  '.zshenv',
+  '.bashrc',
+  '.bash_profile',
+  '.gitconfig',
+  '.vimrc',
+] as const;
+
+const WORKSPACE_ROOT_PATTERNS = [
+  '.editorconfig',
+  '.gitignore',
+  'package.json',
+  'tsconfig.json',
+  'biome.json',
+  'eslint.config.js',
+] as const;
+
+const WORKSPACE_SHALLOW_PATTERNS = [
+  '.config/*',
+  '.config/*/*',
+  '.vscode/*',
+  '.github/*',
+] as const;
+
+export function createEmptyDotfileMap(homeDir = process.env.HOME ?? '~'): DotfileMap {
+  return {
+    homeDir,
+    files: [],
+    tools: [],
+    counts: {
+      totalFiles: 0,
+      knownFiles: 0,
+      unknownFiles: 0,
+      mixedFiles: 0,
+      skippedFiles: 0,
+      warnings: 0,
+    },
+    warningIds: [],
+  };
+}
+
+export async function scanDotfileMap(options: DotfileScanOptions = {}): Promise<DotfileMap> {
+  const homeDir = options.homeDir ?? process.env.HOME ?? '~';
+  const warnings = options.warnings ?? [];
+  const candidates = await collectCandidates({
+    homeDir,
+    dotfilesRepo: options.dotfilesRepo,
+    workspaceRoots: options.workspaceRoots ?? [],
+  });
+
+  const files: DotfileFileSummary[] = [];
+
+  for (const candidate of candidates) {
+    const summary = await summarizeCandidate(candidate, warnings);
+    if (summary) {
+      files.push(summary);
+    }
+  }
+
+  return buildDotfileMap(homeDir, files, warnings);
+}
+
+export function parseShellRcFindings(filePath: string, content: string): DotfileFinding[] {
+  const findings: DotfileFinding[] = [];
+
+  for (const [index, line] of content.split('\n').entries()) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const aliasMatch = trimmed.match(/^alias\s+([^=\s]+)=/);
+    if (aliasMatch) {
+      findings.push(createRcFinding('alias', filePath, index + 1, {
+        name: aliasMatch[1],
+      }));
+      continue;
+    }
+
+    const functionMatch = trimmed.match(/^(?:function\s+)?([A-Za-z_][A-Za-z0-9_-]*)\s*(?:\(\))?\s*\{/);
+    if (functionMatch) {
+      findings.push(createRcFinding('function', filePath, index + 1, {
+        name: functionMatch[1],
+      }));
+      continue;
+    }
+
+    const exportMatch = trimmed.match(/^export\s+([A-Za-z_][A-Za-z0-9_]*)=?(.+)?$/);
+    if (exportMatch) {
+      findings.push(createRcFinding('export', filePath, index + 1, {
+        name: exportMatch[1],
+        valueKind: classifyRcExportValue(exportMatch[2] ?? ''),
+      }));
+      continue;
+    }
+
+    if (/^PATH=|^export\s+PATH=/.test(trimmed)) {
+      findings.push(createRcFinding('path-edit', filePath, index + 1, {
+        name: 'PATH',
+      }));
+      continue;
+    }
+
+    const sourceMatch = trimmed.match(/^(?:source|\.)\s+(.+)$/);
+    if (sourceMatch) {
+      findings.push(createRcFinding('source', filePath, index + 1, {
+        sourceKind: sourceMatch[1].includes('$') ? 'reference' : 'literal',
+      }));
+    }
+  }
+
+  return findings;
+}
+
+export function classifyRcExportValue(rawValue: string): RcExportValueKind {
+  const value = rawValue.trim().replace(/^(['"])(.*)\1$/, '$2');
+  if (!value) {
+    return 'empty';
+  }
+
+  if (/^(ghp_|sk-|AKIA|xox[bp]-|op:\/\/)/.test(value)) {
+    return 'secret-like';
+  }
+
+  if (/\$\(|`/.test(value)) {
+    return 'command-derived';
+  }
+
+  if (/\$[A-Za-z_][A-Za-z0-9_]*|\$\{[^}]+}/.test(value)) {
+    return 'reference';
+  }
+
+  return 'literal';
+}
+
+async function collectCandidates(options: {
+  homeDir: string;
+  dotfilesRepo?: string;
+  workspaceRoots: string[];
+}): Promise<DotfileCandidate[]> {
+  const candidates = new Map<string, DotfileCandidate>();
+
+  addCandidates(candidates, await collectMetadataCandidates(options.homeDir, 'home', options.homeDir));
+  addCandidates(candidates, await collectHomeDotfileCandidates(options.homeDir));
+
+  if (options.dotfilesRepo) {
+    const dotfilesRepo = expandHomePath(options.dotfilesRepo, options.homeDir);
+    addCandidates(candidates, await collectRootAndShallowCandidates(dotfilesRepo, 'dotfiles-repo'));
+  }
+
+  for (const workspaceRoot of options.workspaceRoots) {
+    addCandidates(candidates, await collectWorkspaceCandidates(workspaceRoot));
+  }
+
+  return [...candidates.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+async function collectMetadataCandidates(homeDir: string, scope: DotfileScanScope, rootDir: string): Promise<DotfileCandidate[]> {
+  const candidates: DotfileCandidate[] = [];
+  const metadataPaths = uniqueStrings(allToolMetadata.flatMap(metadata => [
+    ...(metadata.configPaths ?? []),
+    ...(metadata.dotfilePaths ?? []),
+  ]));
+
+  for (const metadataPath of metadataPaths) {
+    const absolutePath = expandHomePath(metadataPath, homeDir);
+    const stat = await statIfExists(absolutePath);
+    if (!stat) {
+      continue;
+    }
+
+    if (stat.isFile() || stat.isSymbolicLink()) {
+      candidates.push({
+        path: absolutePath,
+        scope,
+        queryPath: toRegistryQueryPath(absolutePath, rootDir),
+      });
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      const files = await fg(['**/*'], {
+        cwd: absolutePath,
+        onlyFiles: true,
+        dot: true,
+        deep: 2,
+        followSymbolicLinks: false,
+        absolute: true,
+      });
+
+      for (const filePath of files) {
+        candidates.push({
+          path: filePath,
+          scope,
+          queryPath: toRegistryQueryPath(filePath, rootDir),
+        });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+async function collectHomeDotfileCandidates(homeDir: string): Promise<DotfileCandidate[]> {
+  const files = await fg(['.*'], {
+    cwd: homeDir,
+    onlyFiles: true,
+    dot: true,
+    deep: 1,
+    followSymbolicLinks: false,
+    absolute: true,
+  });
+  const explicitRcFiles = HOME_RC_CANDIDATES.map(fileName => resolve(homeDir, fileName));
+  const filter = createCaptureFilter();
+  const { included } = filterDotfiles([...files, ...explicitRcFiles], filter);
+
+  return uniqueStrings(included).map(filePath => ({
+    path: filePath,
+    scope: 'home',
+    queryPath: toRegistryQueryPath(filePath, homeDir),
+  }));
+}
+
+async function collectRootAndShallowCandidates(rootDir: string, scope: DotfileScanScope): Promise<DotfileCandidate[]> {
+  const files = await fg(['.*', '.config/*', '.vscode/*', '.github/*'], {
+    cwd: rootDir,
+    onlyFiles: true,
+    dot: true,
+    deep: 1,
+    followSymbolicLinks: false,
+    absolute: true,
+  });
+
+  return files.map(filePath => ({
+    path: filePath,
+    scope,
+    queryPath: toRegistryQueryPath(filePath, rootDir),
+  }));
+}
+
+async function collectWorkspaceCandidates(workspaceRoot: string): Promise<DotfileCandidate[]> {
+  const files = await fg([...WORKSPACE_ROOT_PATTERNS, ...WORKSPACE_SHALLOW_PATTERNS], {
+    cwd: workspaceRoot,
+    onlyFiles: true,
+    dot: true,
+    followSymbolicLinks: false,
+    absolute: true,
+  });
+
+  return files.map(filePath => ({
+    path: filePath,
+    scope: 'workspace',
+    queryPath: toRegistryQueryPath(filePath, workspaceRoot),
+  }));
+}
+
+async function summarizeCandidate(
+  candidate: DotfileCandidate,
+  warnings: InventoryWarning[]
+): Promise<DotfileFileSummary | undefined> {
+  const stat = await statIfExists(candidate.path);
+  if (!stat) {
+    return undefined;
+  }
+
+  if (stat.isSymbolicLink()) {
+    const warning = pushDotfileWarning(warnings, `Skipped symlink dotfile candidate: ${candidate.path}`);
+    return {
+      path: candidate.path,
+      scope: candidate.scope,
+      state: 'skipped',
+      toolIds: [],
+      findings: [],
+      warningIds: [warning.id],
+    };
+  }
+
+  if (!stat.isFile()) {
+    return undefined;
+  }
+
+  try {
+    const file = await open(candidate.path, 'r');
+    await file.close();
+  } catch {
+    const warning = pushDotfileWarning(warnings, `Skipped unreadable dotfile candidate: ${candidate.path}`);
+    return {
+      path: candidate.path,
+      scope: candidate.scope,
+      state: 'skipped',
+      toolIds: [],
+      findings: [],
+      warningIds: [warning.id],
+    };
+  }
+
+  const findings = createMetadataFindings(candidate.queryPath);
+  if (findings.length === 0) {
+    findings.push({
+      kind: 'unknown',
+      classification: 'unknown',
+      toolIds: [],
+      reason: 'unmatched-path',
+      confidence: 'low',
+      safeDetails: {
+        pathKind: candidate.queryPath.startsWith('~/.') ? 'dotfile' : 'config',
+      },
+    });
+  }
+
+  const toolIds = uniqueStrings(findings.flatMap(finding => finding.toolIds)).sort();
+
+  return {
+    path: candidate.path,
+    scope: candidate.scope,
+    state: classifyFileState(findings),
+    toolIds,
+    findings,
+    warningIds: [],
+  };
+}
+
+function createMetadataFindings(queryPath: string): DotfileFinding[] {
+  const findings: DotfileFinding[] = [];
+  const configTools = getToolsByConfigPath(queryPath);
+  const dotfileTools = getToolsByDotfilePath(queryPath);
+
+  findings.push(...createMetadataPathFindings(queryPath, configTools, 'config-path'));
+  findings.push(...createMetadataPathFindings(queryPath, dotfileTools, 'dotfile-path'));
+
+  return findings;
+}
+
+function createMetadataPathFindings(
+  queryPath: string,
+  tools: ToolMetadata[],
+  matchType: 'config-path' | 'dotfile-path'
+): DotfileFinding[] {
+  return tools.map(tool => ({
+    kind: 'metadata-path',
+    classification: 'known',
+    toolIds: [tool.id],
+    reason: matchType,
+    confidence: 'high',
+    safeDetails: {
+      matchedPath: findMatchedMetadataPath(queryPath, tool, matchType) ?? queryPath,
+      matchType,
+    },
+  }));
+}
+
+function findMatchedMetadataPath(
+  queryPath: string,
+  tool: ToolMetadata,
+  matchType: 'config-path' | 'dotfile-path'
+): string | undefined {
+  const paths = matchType === 'config-path'
+    ? tool.configPaths ?? []
+    : tool.dotfilePaths ?? [];
+
+  return paths.find(path => pathMatches(path, queryPath));
+}
+
+function buildDotfileMap(homeDir: string, files: DotfileFileSummary[], warnings: InventoryWarning[]): DotfileMap {
+  const toolSummaries = new Map<string, DotfileToolSummary>();
+
+  for (const file of files) {
+    for (const finding of file.findings) {
+      for (const toolId of finding.toolIds) {
+        const metadata = allToolMetadata.find(tool => tool.id === toolId);
+        const summary = toolSummaries.get(toolId) ?? {
+          toolId,
+          label: metadata?.label ?? toolId,
+          category: metadata?.category ?? 'unknown',
+          knownFileCount: 0,
+          findingCount: 0,
+          paths: [],
+        };
+
+        summary.findingCount += 1;
+        if (!summary.paths.includes(file.path)) {
+          summary.paths.push(file.path);
+          summary.knownFileCount += 1;
+        }
+        toolSummaries.set(toolId, summary);
+      }
+    }
+  }
+
+  const dotfileWarnings = warnings.filter(warning => warning.source === 'dotfiles');
+
+  return {
+    homeDir,
+    files: files.sort((a, b) => a.path.localeCompare(b.path)),
+    tools: [...toolSummaries.values()].sort((a, b) => a.toolId.localeCompare(b.toolId)),
+    counts: {
+      totalFiles: files.length,
+      knownFiles: files.filter(file => file.state === 'known').length,
+      unknownFiles: files.filter(file => file.state === 'unknown').length,
+      mixedFiles: files.filter(file => file.state === 'mixed').length,
+      skippedFiles: files.filter(file => file.state === 'skipped').length,
+      warnings: dotfileWarnings.length,
+    },
+    warningIds: dotfileWarnings.map(warning => warning.id),
+  };
+}
+
+function createRcFinding(
+  kind: Exclude<DotfileFindingKind, 'metadata-path' | 'unknown' | 'tool-init-hook'>,
+  filePath: string,
+  line: number,
+  safeDetails: Record<string, string | string[] | boolean | number>
+): DotfileFinding {
+  return {
+    kind,
+    classification: 'unknown',
+    toolIds: [],
+    reason: 'rc-file-content',
+    confidence: 'medium',
+    safeDetails: {
+      filePath,
+      line,
+      ...safeDetails,
+    },
+  };
+}
+
+function classifyFileState(findings: DotfileFinding[]): DotfileFileState {
+  const hasKnown = findings.some(finding => finding.classification === 'known');
+  const hasUnknown = findings.some(finding => finding.classification === 'unknown');
+
+  if (hasKnown && hasUnknown) {
+    return 'mixed';
+  }
+
+  if (hasKnown) {
+    return 'known';
+  }
+
+  return 'unknown';
+}
+
+function pushDotfileWarning(warnings: InventoryWarning[], message: string): InventoryWarning {
+  const warning: InventoryWarning = {
+    id: `dotfiles-${warnings.filter(existing => existing.source === 'dotfiles').length + 1}`,
+    source: 'dotfiles',
+    severity: 'warning',
+    message,
+  };
+  warnings.push(warning);
+  return warning;
+}
+
+function addCandidates(target: Map<string, DotfileCandidate>, candidates: DotfileCandidate[]): void {
+  for (const candidate of candidates) {
+    target.set(`${candidate.scope}:${candidate.path}`, candidate);
+  }
+}
+
+function expandHomePath(filePath: string, homeDir: string): string {
+  if (filePath === '~') {
+    return homeDir;
+  }
+
+  if (filePath.startsWith('~/')) {
+    return resolve(homeDir, filePath.slice(2));
+  }
+
+  return resolve(filePath);
+}
+
+function toRegistryQueryPath(filePath: string, rootDir: string): string {
+  const relativePath = relative(rootDir, filePath);
+  if (!relativePath || relativePath.startsWith('..') || relativePath.split(sep).includes('..')) {
+    return filePath;
+  }
+
+  return `~/${relativePath.split(sep).join('/')}`;
+}
+
+async function statIfExists(filePath: string) {
+  try {
+    return await lstat(filePath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    ((error as { code?: string }).code === 'ENOENT' || (error as { code?: string }).code === 'ENOTDIR');
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function pathMatches(knownPath: string, queryPath: string): boolean {
+  const normalizedKnownPath = normalizePath(knownPath);
+  const normalizedQueryPath = normalizePath(queryPath);
+
+  return normalizedQueryPath === normalizedKnownPath ||
+    normalizedQueryPath.startsWith(`${normalizedKnownPath}/`);
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.trim().replace(/\/+$/, '');
+}

--- a/src/inventory/dotfiles.ts
+++ b/src/inventory/dotfiles.ts
@@ -135,6 +135,7 @@ export async function scanDotfileMap(options: DotfileScanOptions = {}): Promise<
     homeDir,
     dotfilesRepo: options.dotfilesRepo,
     workspaceRoots: options.workspaceRoots ?? [],
+    warnings,
   });
 
   const files: DotfileFileSummary[] = [];
@@ -233,25 +234,40 @@ async function collectCandidates(options: {
   homeDir: string;
   dotfilesRepo?: string;
   workspaceRoots: string[];
+  warnings: InventoryWarning[];
 }): Promise<DotfileCandidate[]> {
   const candidates = new Map<string, DotfileCandidate>();
+  const filter = createCaptureFilter();
 
-  addCandidates(candidates, await collectMetadataCandidates(options.homeDir, 'home', options.homeDir));
-  addCandidates(candidates, await collectHomeDotfileCandidates(options.homeDir));
+  addCandidates(candidates, await collectSafely(options.warnings, 'home', () =>
+    collectMetadataCandidates(options.homeDir, 'home', options.homeDir, filter)
+  ));
+  addCandidates(candidates, await collectSafely(options.warnings, 'home', () =>
+    collectHomeDotfileCandidates(options.homeDir)
+  ));
 
   if (options.dotfilesRepo) {
     const dotfilesRepo = expandHomePath(options.dotfilesRepo, options.homeDir);
-    addCandidates(candidates, await collectRootAndShallowCandidates(dotfilesRepo, 'dotfiles-repo'));
+    addCandidates(candidates, await collectSafely(options.warnings, 'dotfiles-repo', () =>
+      collectRootAndShallowCandidates(dotfilesRepo, 'dotfiles-repo', filter)
+    ));
   }
 
   for (const workspaceRoot of options.workspaceRoots) {
-    addCandidates(candidates, await collectWorkspaceCandidates(workspaceRoot));
+    addCandidates(candidates, await collectSafely(options.warnings, 'workspace', () =>
+      collectWorkspaceCandidates(workspaceRoot, filter)
+    ));
   }
 
   return [...candidates.values()].sort((a, b) => a.path.localeCompare(b.path));
 }
 
-async function collectMetadataCandidates(homeDir: string, scope: DotfileScanScope, rootDir: string): Promise<DotfileCandidate[]> {
+async function collectMetadataCandidates(
+  homeDir: string,
+  scope: DotfileScanScope,
+  rootDir: string,
+  filter: ReturnType<typeof createCaptureFilter>
+): Promise<DotfileCandidate[]> {
   const candidates: DotfileCandidate[] = [];
   const metadataPaths = uniqueStrings(allToolMetadata.flatMap(metadata => [
     ...(metadata.configPaths ?? []),
@@ -266,6 +282,10 @@ async function collectMetadataCandidates(homeDir: string, scope: DotfileScanScop
     }
 
     if (stat.isFile() || stat.isSymbolicLink()) {
+      if (!shouldScanCandidate(absolutePath, rootDir, filter)) {
+        continue;
+      }
+
       candidates.push({
         path: absolutePath,
         scope,
@@ -285,6 +305,10 @@ async function collectMetadataCandidates(homeDir: string, scope: DotfileScanScop
       });
 
       for (const filePath of files) {
+        if (!shouldScanCandidate(filePath, rootDir, filter)) {
+          continue;
+        }
+
         candidates.push({
           path: filePath,
           scope,
@@ -317,7 +341,11 @@ async function collectHomeDotfileCandidates(homeDir: string): Promise<DotfileCan
   }));
 }
 
-async function collectRootAndShallowCandidates(rootDir: string, scope: DotfileScanScope): Promise<DotfileCandidate[]> {
+async function collectRootAndShallowCandidates(
+  rootDir: string,
+  scope: DotfileScanScope,
+  filter: ReturnType<typeof createCaptureFilter>
+): Promise<DotfileCandidate[]> {
   const files = await fg(['.*', '.config/*', '.vscode/*', '.github/*'], {
     cwd: rootDir,
     onlyFiles: true,
@@ -327,14 +355,19 @@ async function collectRootAndShallowCandidates(rootDir: string, scope: DotfileSc
     absolute: true,
   });
 
-  return files.map(filePath => ({
-    path: filePath,
-    scope,
-    queryPath: toRegistryQueryPath(filePath, rootDir),
-  }));
+  return files
+    .filter(filePath => shouldScanCandidate(filePath, rootDir, filter))
+    .map(filePath => ({
+      path: filePath,
+      scope,
+      queryPath: toRegistryQueryPath(filePath, rootDir),
+    }));
 }
 
-async function collectWorkspaceCandidates(workspaceRoot: string): Promise<DotfileCandidate[]> {
+async function collectWorkspaceCandidates(
+  workspaceRoot: string,
+  filter: ReturnType<typeof createCaptureFilter>
+): Promise<DotfileCandidate[]> {
   const files = await fg([...WORKSPACE_ROOT_PATTERNS, ...WORKSPACE_SHALLOW_PATTERNS], {
     cwd: workspaceRoot,
     onlyFiles: true,
@@ -343,11 +376,13 @@ async function collectWorkspaceCandidates(workspaceRoot: string): Promise<Dotfil
     absolute: true,
   });
 
-  return files.map(filePath => ({
-    path: filePath,
-    scope: 'workspace',
-    queryPath: toRegistryQueryPath(filePath, workspaceRoot),
-  }));
+  return files
+    .filter(filePath => shouldScanCandidate(filePath, workspaceRoot, filter))
+    .map(filePath => ({
+      path: filePath,
+      scope: 'workspace',
+      queryPath: toRegistryQueryPath(filePath, workspaceRoot),
+    }));
 }
 
 async function summarizeCandidate(
@@ -360,7 +395,7 @@ async function summarizeCandidate(
   }
 
   if (stat.isSymbolicLink()) {
-    const warning = pushDotfileWarning(warnings, `Skipped symlink dotfile candidate: ${candidate.path}`);
+    const warning = pushDotfileWarning(warnings, 'Skipped symlink dotfile candidate.');
     return {
       path: candidate.path,
       scope: candidate.scope,
@@ -379,7 +414,7 @@ async function summarizeCandidate(
   try {
     content = await readFile(candidate.path, 'utf-8');
   } catch {
-    const warning = pushDotfileWarning(warnings, `Skipped unreadable dotfile candidate: ${candidate.path}`);
+    const warning = pushDotfileWarning(warnings, 'Skipped unreadable dotfile candidate.');
     return {
       path: candidate.path,
       scope: candidate.scope,
@@ -529,19 +564,19 @@ function parseKnownHook(trimmed: string, filePath: string, line: number): Dotfil
 }
 
 function knownHookForLine(trimmed: string): { toolId: string; hookKind: string } | undefined {
-  if (/\bdirenv\s+hook\b/.test(trimmed)) {
+  if (/^eval\s+['"]?\$\(direnv\s+hook\s+[^)]+\)['"]?$/.test(trimmed)) {
     return { toolId: 'direnv', hookKind: 'shell-hook' };
   }
 
-  if (/\bvfox\s+activate\b/.test(trimmed)) {
+  if (/^eval\s+['"]?\$\(vfox\s+activate\s+[^)]+\)['"]?$/.test(trimmed)) {
     return { toolId: 'vfox', hookKind: 'shell-hook' };
   }
 
-  if (/\bop\s+signin\b/.test(trimmed)) {
+  if (/^eval\s+['"]?\$\(op\s+signin\)['"]?$/.test(trimmed)) {
     return { toolId: '1password', hookKind: 'runtime-init' };
   }
 
-  if (/\bbrew\s+shellenv\b/.test(trimmed)) {
+  if (/^eval\s+['"]?\$\([^)]*\bbrew\s+shellenv\)['"]?$/.test(trimmed)) {
     return { toolId: 'homebrew', hookKind: 'shellenv' };
   }
 
@@ -569,15 +604,14 @@ function createRcFinding(
 }
 
 function createSourceFinding(filePath: string, line: number, rawTarget: string): DotfileFinding {
-  const target = stripInlineComment(rawTarget).trim().replace(/^(['"])(.*)\1$/, '$2');
-  const sourceKind = classifySourceTarget(target);
+  const { sourceKind, target } = parseSourceTarget(rawTarget);
   const safeDetails: Record<string, string | number> = {
     filePath,
     line,
     sourceKind,
   };
 
-  if (sourceKind !== 'command-derived') {
+  if (target) {
     safeDetails.target = target;
   }
 
@@ -588,6 +622,26 @@ function createSourceFinding(filePath: string, line: number, rawTarget: string):
     reason: 'rc-file-content',
     confidence: 'medium',
     safeDetails,
+  };
+}
+
+function parseSourceTarget(rawTarget: string): {
+  sourceKind: 'literal' | 'reference' | 'command-derived';
+  target?: string;
+} {
+  const stripped = stripInlineComment(rawTarget).trim();
+  if (!stripped || /[;&|<>]/.test(stripped) || /\$\(|`/.test(stripped)) {
+    return { sourceKind: 'command-derived' };
+  }
+
+  const target = stripped.replace(/^(['"])(.*)\1$/, '$2');
+  if (!target || classifyRcExportValue(target) === 'secret-like') {
+    return { sourceKind: 'command-derived' };
+  }
+
+  return {
+    sourceKind: classifySourceTarget(target),
+    target,
   };
 }
 
@@ -673,6 +727,19 @@ function addCandidates(target: Map<string, DotfileCandidate>, candidates: Dotfil
   }
 }
 
+async function collectSafely(
+  warnings: InventoryWarning[],
+  scope: DotfileScanScope,
+  operation: () => Promise<DotfileCandidate[]>
+): Promise<DotfileCandidate[]> {
+  try {
+    return await operation();
+  } catch {
+    pushDotfileWarning(warnings, `Skipped ${scope} dotfile scan segment.`);
+    return [];
+  }
+}
+
 function expandHomePath(filePath: string, homeDir: string): string {
   if (filePath === '~') {
     return homeDir;
@@ -704,6 +771,24 @@ async function statIfExists(filePath: string) {
 
     throw error;
   }
+}
+
+function shouldScanCandidate(
+  filePath: string,
+  rootDir: string,
+  filter: ReturnType<typeof createCaptureFilter>
+): boolean {
+  const relativePath = toFilterPath(filePath, rootDir);
+  return !filter.ignores(basename(filePath)) && !filter.ignores(relativePath);
+}
+
+function toFilterPath(filePath: string, rootDir: string): string {
+  const relativePath = relative(rootDir, filePath);
+  if (!relativePath || relativePath.startsWith('..') || relativePath.split(sep).includes('..')) {
+    return basename(filePath);
+  }
+
+  return relativePath.split(sep).join('/');
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/src/inventory/dotfiles.ts
+++ b/src/inventory/dotfiles.ts
@@ -1,5 +1,5 @@
-import { lstat, open } from 'node:fs/promises';
-import { relative, resolve, sep } from 'node:path';
+import { lstat, readFile } from 'node:fs/promises';
+import { basename, relative, resolve, sep } from 'node:path';
 import fg from 'fast-glob';
 import { createCaptureFilter, filterDotfiles } from '../capture/filter.js';
 import { allToolMetadata, getToolsByConfigPath, getToolsByDotfilePath } from '../tools/registry.js';
@@ -64,6 +64,8 @@ export interface DotfileMap {
     mixedFiles: number;
     skippedFiles: number;
     warnings: number;
+    knownFindingsCount: number;
+    unknownFindingsCount: number;
   };
   warningIds: string[];
 }
@@ -119,6 +121,8 @@ export function createEmptyDotfileMap(homeDir = process.env.HOME ?? '~'): Dotfil
       mixedFiles: 0,
       skippedFiles: 0,
       warnings: 0,
+      knownFindingsCount: 0,
+      unknownFindingsCount: 0,
     },
     warningIds: [],
   };
@@ -154,6 +158,12 @@ export function parseShellRcFindings(filePath: string, content: string): Dotfile
       continue;
     }
 
+    const hookFinding = parseKnownHook(trimmed, filePath, index + 1);
+    if (hookFinding) {
+      findings.push(hookFinding);
+      continue;
+    }
+
     const aliasMatch = trimmed.match(/^alias\s+([^=\s]+)=/);
     if (aliasMatch) {
       findings.push(createRcFinding('alias', filePath, index + 1, {
@@ -170,6 +180,16 @@ export function parseShellRcFindings(filePath: string, content: string): Dotfile
       continue;
     }
 
+    const pathMatch = trimmed.match(/^(?:export\s+)?PATH(?:\+)?=(.+)$/);
+    if (pathMatch) {
+      findings.push(createRcFinding('path-edit', filePath, index + 1, {
+        name: 'PATH',
+        valueKind: classifyRcExportValue(pathMatch[1] ?? ''),
+        editKind: classifyPathEdit(pathMatch[1] ?? ''),
+      }));
+      continue;
+    }
+
     const exportMatch = trimmed.match(/^export\s+([A-Za-z_][A-Za-z0-9_]*)=?(.+)?$/);
     if (exportMatch) {
       findings.push(createRcFinding('export', filePath, index + 1, {
@@ -179,18 +199,9 @@ export function parseShellRcFindings(filePath: string, content: string): Dotfile
       continue;
     }
 
-    if (/^PATH=|^export\s+PATH=/.test(trimmed)) {
-      findings.push(createRcFinding('path-edit', filePath, index + 1, {
-        name: 'PATH',
-      }));
-      continue;
-    }
-
-    const sourceMatch = trimmed.match(/^(?:source|\.)\s+(.+)$/);
+    const sourceMatch = trimmed.match(/(?:^|&&\s*|\|\|\s*)(?:source|\.)\s+(.+)$/);
     if (sourceMatch) {
-      findings.push(createRcFinding('source', filePath, index + 1, {
-        sourceKind: sourceMatch[1].includes('$') ? 'reference' : 'literal',
-      }));
+      findings.push(createSourceFinding(filePath, index + 1, sourceMatch[1]));
     }
   }
 
@@ -364,9 +375,9 @@ async function summarizeCandidate(
     return undefined;
   }
 
+  let content: string;
   try {
-    const file = await open(candidate.path, 'r');
-    await file.close();
+    content = await readFile(candidate.path, 'utf-8');
   } catch {
     const warning = pushDotfileWarning(warnings, `Skipped unreadable dotfile candidate: ${candidate.path}`);
     return {
@@ -380,6 +391,10 @@ async function summarizeCandidate(
   }
 
   const findings = createMetadataFindings(candidate.queryPath);
+  if (isRcFile(candidate.path)) {
+    findings.push(...parseShellRcFindings(candidate.path, content));
+  }
+
   if (findings.length === 0) {
     findings.push({
       kind: 'unknown',
@@ -485,9 +500,52 @@ function buildDotfileMap(homeDir: string, files: DotfileFileSummary[], warnings:
       mixedFiles: files.filter(file => file.state === 'mixed').length,
       skippedFiles: files.filter(file => file.state === 'skipped').length,
       warnings: dotfileWarnings.length,
+      knownFindingsCount: files.reduce((count, file) => count + file.findings.filter(isKnownRcFinding).length, 0),
+      unknownFindingsCount: files.reduce((count, file) => count + file.findings.filter(isUnknownRcFinding).length, 0),
     },
     warningIds: dotfileWarnings.map(warning => warning.id),
   };
+}
+
+function parseKnownHook(trimmed: string, filePath: string, line: number): DotfileFinding | undefined {
+  const hook = knownHookForLine(trimmed);
+  if (!hook) {
+    return undefined;
+  }
+
+  return {
+    kind: 'tool-init-hook',
+    classification: 'known',
+    toolIds: [hook.toolId],
+    reason: 'rc-file-content',
+    confidence: 'high',
+    safeDetails: {
+      filePath,
+      line,
+      toolId: hook.toolId,
+      hookKind: hook.hookKind,
+    },
+  };
+}
+
+function knownHookForLine(trimmed: string): { toolId: string; hookKind: string } | undefined {
+  if (/\bdirenv\s+hook\b/.test(trimmed)) {
+    return { toolId: 'direnv', hookKind: 'shell-hook' };
+  }
+
+  if (/\bvfox\s+activate\b/.test(trimmed)) {
+    return { toolId: 'vfox', hookKind: 'shell-hook' };
+  }
+
+  if (/\bop\s+signin\b/.test(trimmed)) {
+    return { toolId: '1password', hookKind: 'runtime-init' };
+  }
+
+  if (/\bbrew\s+shellenv\b/.test(trimmed)) {
+    return { toolId: 'homebrew', hookKind: 'shellenv' };
+  }
+
+  return undefined;
 }
 
 function createRcFinding(
@@ -508,6 +566,65 @@ function createRcFinding(
       ...safeDetails,
     },
   };
+}
+
+function createSourceFinding(filePath: string, line: number, rawTarget: string): DotfileFinding {
+  const target = stripInlineComment(rawTarget).trim().replace(/^(['"])(.*)\1$/, '$2');
+  const sourceKind = classifySourceTarget(target);
+  const safeDetails: Record<string, string | number> = {
+    filePath,
+    line,
+    sourceKind,
+  };
+
+  if (sourceKind !== 'command-derived') {
+    safeDetails.target = target;
+  }
+
+  return {
+    kind: 'source',
+    classification: 'unknown',
+    toolIds: [],
+    reason: 'rc-file-content',
+    confidence: 'medium',
+    safeDetails,
+  };
+}
+
+function classifySourceTarget(target: string): 'literal' | 'reference' | 'command-derived' {
+  if (/\$\(|`/.test(target)) {
+    return 'command-derived';
+  }
+
+  if (/\$[A-Za-z_][A-Za-z0-9_]*|\$\{[^}]+}/.test(target)) {
+    return 'reference';
+  }
+
+  return 'literal';
+}
+
+function classifyPathEdit(value: string): 'assignment' | 'prepend' | 'append' | 'reference' {
+  const normalized = value.trim().replace(/^(['"])(.*)\1$/, '$2');
+  const pathRefIndex = normalized.indexOf('$PATH');
+
+  if (pathRefIndex === -1) {
+    return 'assignment';
+  }
+
+  if (pathRefIndex === 0) {
+    return 'append';
+  }
+
+  if (pathRefIndex > 0) {
+    return 'prepend';
+  }
+
+  return 'reference';
+}
+
+function stripInlineComment(value: string): string {
+  const commentIndex = value.indexOf(' #');
+  return commentIndex === -1 ? value : value.slice(0, commentIndex);
 }
 
 function classifyFileState(findings: DotfileFinding[]): DotfileFileState {
@@ -534,6 +651,20 @@ function pushDotfileWarning(warnings: InventoryWarning[], message: string): Inve
   };
   warnings.push(warning);
   return warning;
+}
+
+function isRcFile(filePath: string): boolean {
+  return HOME_RC_CANDIDATES.includes(basename(filePath) as typeof HOME_RC_CANDIDATES[number]);
+}
+
+function isKnownRcFinding(finding: DotfileFinding): boolean {
+  return finding.kind === 'tool-init-hook' && finding.classification === 'known';
+}
+
+function isUnknownRcFinding(finding: DotfileFinding): boolean {
+  return finding.classification === 'unknown' &&
+    finding.kind !== 'metadata-path' &&
+    finding.kind !== 'unknown';
 }
 
 function addCandidates(target: Map<string, DotfileCandidate>, candidates: DotfileCandidate[]): void {

--- a/src/inventory/report.ts
+++ b/src/inventory/report.ts
@@ -1,6 +1,7 @@
 import type { DetectedLanguage, DetectedVersionManager } from '../utils/env-detection.js';
 import type { ToolCategory } from '../tools/metadata.js';
 import type { ClassifiedHomebrewCask, ClassifiedHomebrewFormula, HomebrewRequestStatus } from './homebrew.js';
+import { createEmptyDotfileMap, type DotfileMap } from './dotfiles.js';
 
 export type InventoryInstallState = 'installed' | 'missing' | 'unknown';
 
@@ -8,7 +9,7 @@ export type InventoryToolCategory = ToolCategory | 'shell' | 'core-tool';
 
 export type InventoryWarningSeverity = 'info' | 'warning' | 'error';
 
-export type InventoryWarningSource = 'homebrew' | 'environment' | 'app-path' | 'scanner';
+export type InventoryWarningSource = 'homebrew' | 'environment' | 'app-path' | 'scanner' | 'dotfiles';
 
 export type InventoryEvidence =
   | { type: 'homebrew-formula'; id: string; requestStatus: HomebrewRequestStatus }
@@ -64,6 +65,7 @@ export interface InventoryReport {
   tools: InventoryToolFact[];
   unmatchedHomebrew: InventoryHomebrewAudit;
   homebrew: InventoryHomebrewSummary;
+  dotfiles: DotfileMap;
   warnings: InventoryWarning[];
   environment: InventoryEnvironmentSnapshot;
 }
@@ -93,6 +95,7 @@ export function createEmptyInventoryReport(homeDir = process.env.HOME ?? '~'): I
       dependencyFormulaeCount: 0,
       unknownFormulaeCount: 0,
     },
+    dotfiles: createEmptyDotfileMap(homeDir),
     warnings: [],
     environment: {
       homeDir,

--- a/src/inventory/scan.ts
+++ b/src/inventory/scan.ts
@@ -11,6 +11,7 @@ import {
   type DetectedVersionManager,
 } from '../utils/env-detection.js';
 import { classifyHomebrewInventory, type ClassifiedHomebrewCask, type ClassifiedHomebrewFormula } from './homebrew.js';
+import { scanDotfileMap } from './dotfiles.js';
 import {
   createEmptyInventoryReport,
   type InventoryEvidence,
@@ -21,6 +22,11 @@ import {
   type InventoryWarningSource,
 } from './report.js';
 
+export interface InventoryScanOptions {
+  dotfilesRepo?: string;
+  workspaceRoots?: string[];
+}
+
 type HomebrewResult = {
   formulae: ClassifiedHomebrewFormula[] | null;
   casks: ClassifiedHomebrewCask[] | null;
@@ -30,7 +36,7 @@ type HomebrewResult = {
 const CORE_TOOL_IDS = ['git', 'node', 'npm'] as const;
 const SHELL_IDS = ['zsh', 'bash'] as const;
 
-export async function scanInventory(homeDir?: string): Promise<InventoryReport> {
+export async function scanInventory(homeDir?: string, options: InventoryScanOptions = {}): Promise<InventoryReport> {
   const resolvedHome = homeDir ?? process.env.HOME ?? '~';
   const report = createEmptyInventoryReport(resolvedHome);
   const warnings = report.warnings;
@@ -49,6 +55,12 @@ export async function scanInventory(homeDir?: string): Promise<InventoryReport> 
     detectedLanguages: await scanDetectedLanguages(warnings),
     detectedVersionManagers: await scanDetectedVersionManagers(warnings),
   };
+  report.dotfiles = await scanDotfileMap({
+    homeDir: resolvedHome,
+    dotfilesRepo: options.dotfilesRepo,
+    workspaceRoots: options.workspaceRoots,
+    warnings,
+  });
 
   const matchedFormulae = new Set<string>();
   const matchedCasks = new Set<string>();

--- a/src/inventory/summary.ts
+++ b/src/inventory/summary.ts
@@ -16,6 +16,12 @@ export function summarizeInventory(report: InventoryReport): string[] {
     `Dotfiles: ${report.dotfiles.counts.knownFiles} known, ${report.dotfiles.counts.unknownFiles} unknown, ${report.dotfiles.counts.warnings} warnings`,
   ];
 
+  if (report.dotfiles.counts.knownFindingsCount > 0 || report.dotfiles.counts.unknownFindingsCount > 0) {
+    lines.push(
+      `Dotfile findings: ${report.dotfiles.counts.knownFindingsCount} known hooks, ${report.dotfiles.counts.unknownFindingsCount} unknown rc findings`
+    );
+  }
+
   if (report.warnings.length > 0) {
     lines.push('Warnings:');
     for (const warning of report.warnings) {

--- a/src/inventory/summary.ts
+++ b/src/inventory/summary.ts
@@ -13,6 +13,7 @@ export function summarizeInventory(report: InventoryReport): string[] {
     `Known installed tools: ${installedKnownToolSummary}`,
     `Homebrew formulae: ${report.homebrew.directFormulaeCount} direct, ${report.homebrew.dependencyFormulaeCount} dependencies, ${report.homebrew.unknownFormulaeCount} unknown`,
     `Homebrew casks: ${report.homebrew.installedCasksCount} installed, ${report.homebrew.unmatchedCasksCount} unmatched`,
+    `Dotfiles: ${report.dotfiles.counts.knownFiles} known, ${report.dotfiles.counts.unknownFiles} unknown, ${report.dotfiles.counts.warnings} warnings`,
   ];
 
   if (report.warnings.length > 0) {

--- a/tests/integration/config-first.test.ts
+++ b/tests/integration/config-first.test.ts
@@ -26,6 +26,65 @@ vi.mock('../../src/plugins/registry.js', () => ({
 
 describe('ConfigFirstMode integration', () => {
   function createInventoryFixture(): InventoryReport {
+    const dotfiles = {
+      ...createEmptyInventoryReport().dotfiles,
+      files: [
+        {
+          path: '/Users/test/.zshrc',
+          scope: 'home' as const,
+          state: 'mixed' as const,
+          toolIds: ['direnv'],
+          warningIds: [],
+          findings: [
+            {
+              kind: 'tool-init-hook' as const,
+              classification: 'known' as const,
+              toolIds: ['direnv'],
+              reason: 'rc-file-content',
+              confidence: 'high' as const,
+              safeDetails: { toolId: 'direnv', sourceLine: 'eval "$(direnv hook zsh)"' },
+            },
+            {
+              kind: 'alias' as const,
+              classification: 'unknown' as const,
+              toolIds: [],
+              reason: 'rc-file-content',
+              confidence: 'medium' as const,
+              safeDetails: { name: 'gs', sourceLine: 'alias gs="git status"' },
+            },
+            {
+              kind: 'source' as const,
+              classification: 'unknown' as const,
+              toolIds: [],
+              reason: 'rc-file-content',
+              confidence: 'medium' as const,
+              safeDetails: { target: '~/.private-aliases' },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          toolId: 'direnv',
+          label: 'direnv',
+          category: 'env-loader',
+          knownFileCount: 1,
+          findingCount: 1,
+          paths: ['/Users/test/.zshrc'],
+        },
+      ],
+      counts: {
+        totalFiles: 1,
+        knownFiles: 0,
+        unknownFiles: 0,
+        mixedFiles: 1,
+        skippedFiles: 0,
+        warnings: 0,
+        knownFindingsCount: 1,
+        unknownFindingsCount: 2,
+      },
+    };
+
     return {
       ...createEmptyInventoryReport(),
       tools: [
@@ -53,6 +112,7 @@ describe('ConfigFirstMode integration', () => {
         dependencyFormulaeCount: 1,
         unknownFormulaeCount: 0,
       },
+      dotfiles,
       warnings: [
         {
           id: 'homebrew-request-state-unavailable',
@@ -122,9 +182,14 @@ describe('ConfigFirstMode integration', () => {
     const inventoryBlock = frame.slice(inventoryIndex, configIndex);
     expect(inventoryBlock).toContain('Known installed tools: Homebrew');
     expect(inventoryBlock).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
+    expect(inventoryBlock).toContain('Dotfiles:');
+    expect(inventoryBlock).toContain('Dotfile findings: 1 known hooks, 2 unknown rc findings');
     expect(inventoryBlock).toContain('Warnings:');
     expect(inventoryBlock).toContain('Warning: Homebrew direct/dependency status is unavailable.');
     expect(inventoryBlock).not.toContain('ripgrep');
+    expect(inventoryBlock).not.toContain('alias gs=');
+    expect(inventoryBlock).not.toContain('eval "$(direnv hook zsh)"');
+    expect(inventoryBlock).not.toContain('~/.private-aliases');
   });
 
   it('withholds apply choices while inventory is loading', async () => {

--- a/tests/integration/env-capture.test.ts
+++ b/tests/integration/env-capture.test.ts
@@ -1,6 +1,4 @@
-import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render } from 'ink-testing-library';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -164,22 +162,13 @@ describe('inventory integration', () => {
     };
   }
 
-  it('inventory step renders known installed tools and warnings from an InventoryReport', async () => {
-    const { InventoryStep } = await import('../../src/steps/inventory.js');
-    const onComplete = vi.fn();
+  it('inventory summary includes known installed tools and warnings from an InventoryReport', () => {
+    const report = createInventoryFixture();
+    const labels = report.tools.map(tool => tool.label);
+    const warnings = report.warnings.map(warning => warning.message);
 
-    const { lastFrame } = render(
-      React.createElement(InventoryStep, {
-        inventory: createInventoryFixture(),
-        onComplete,
-      })
-    );
-
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('Inventory scan complete');
-    expect(frame).toContain('Known installed tools:');
-    expect(frame).toContain('Homebrew');
-    expect(frame).toContain('Visual Studio Code');
-    expect(frame).toContain('Warning: Inventory scan failed; continuing with an empty report.');
+    expect(labels).toContain('Homebrew');
+    expect(labels).toContain('Visual Studio Code');
+    expect(warnings).toContain('Inventory scan failed; continuing with an empty report.');
   });
 });

--- a/tests/integration/wizard-flow.test.tsx
+++ b/tests/integration/wizard-flow.test.tsx
@@ -40,6 +40,65 @@ vi.mock('node:fs/promises', async () => {
 
 describe('Wizard flow integration', () => {
   function createInventoryFixture(overrides: Partial<InventoryReport> = {}): InventoryReport {
+    const dotfiles = {
+      ...createEmptyInventoryReport().dotfiles,
+      files: [
+        {
+          path: '/Users/test/.zshrc',
+          scope: 'home' as const,
+          state: 'mixed' as const,
+          toolIds: ['direnv', 'vfox'],
+          warningIds: [],
+          findings: [
+            {
+              kind: 'tool-init-hook' as const,
+              classification: 'known' as const,
+              toolIds: ['direnv'],
+              reason: 'rc-file-content',
+              confidence: 'high' as const,
+              safeDetails: { toolId: 'direnv', sourceLine: 'eval "$(direnv hook zsh)"' },
+            },
+            {
+              kind: 'alias' as const,
+              classification: 'unknown' as const,
+              toolIds: [],
+              reason: 'rc-file-content',
+              confidence: 'medium' as const,
+              safeDetails: { name: 'gs', sourceLine: 'alias gs="git status"' },
+            },
+            {
+              kind: 'source' as const,
+              classification: 'unknown' as const,
+              toolIds: [],
+              reason: 'rc-file-content',
+              confidence: 'medium' as const,
+              safeDetails: { target: '~/.private-aliases' },
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          toolId: 'direnv',
+          label: 'direnv',
+          category: 'env-loader',
+          knownFileCount: 1,
+          findingCount: 1,
+          paths: ['/Users/test/.zshrc'],
+        },
+      ],
+      counts: {
+        totalFiles: 1,
+        knownFiles: 0,
+        unknownFiles: 0,
+        mixedFiles: 1,
+        skippedFiles: 0,
+        warnings: 0,
+        knownFindingsCount: 1,
+        unknownFindingsCount: 2,
+      },
+    };
+
     return {
       ...createEmptyInventoryReport(),
       tools: [
@@ -75,6 +134,7 @@ describe('Wizard flow integration', () => {
         dependencyFormulaeCount: 1,
         unknownFormulaeCount: 0,
       },
+      dotfiles,
       warnings: [],
       environment: {
         homeDir: '~',
@@ -315,6 +375,7 @@ describe('Wizard flow integration', () => {
     expect(frame).not.toContain('Environment Capture');
     expect(frame).toContain('Inventory scan complete');
     expect(frame).toContain('Known installed tools:');
+    expect(frame).toContain('Dotfiles:');
   });
 
   it('inventory wizard step summarizes Homebrew counts and warnings without unmatched names', async () => {
@@ -342,9 +403,13 @@ describe('Wizard flow integration', () => {
     expect(frame).toContain('Inventory scan complete');
     expect(frame).toContain('Known installed tools:');
     expect(frame).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
+    expect(frame).toContain('Dotfile findings: 1 known hooks, 2 unknown rc findings');
     expect(frame).toContain('Warnings:');
     expect(frame).toContain('Warning: Homebrew direct/dependency status is unavailable.');
     expect(frame).not.toContain('ripgrep');
+    expect(frame).not.toContain('alias gs=');
+    expect(frame).not.toContain('eval "$(direnv hook zsh)"');
+    expect(frame).not.toContain('~/.private-aliases');
   });
 
   it('inventory wizard step shows startup scan failure warnings without blocking rendering', async () => {

--- a/tests/unit/inventory-dotfiles.test.ts
+++ b/tests/unit/inventory-dotfiles.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { scanDotfileMap, type DotfileMap } from '../../src/inventory/dotfiles.js';
+import type { InventoryWarning } from '../../src/inventory/report.js';
+
+function fileByPath(map: DotfileMap, filePath: string) {
+  return map.files.find(file => file.path === filePath);
+}
+
+describe('inventory dotfile scanner', () => {
+  let tmpRoot: string;
+  let tmpHome: string;
+  let dotfilesRepo: string;
+  let workspaceRoot: string;
+  let warnings: InventoryWarning[];
+
+  beforeEach(async () => {
+    tmpRoot = join(tmpdir(), `tilde-dotfiles-test-${randomUUID()}`);
+    tmpHome = join(tmpRoot, 'home');
+    dotfilesRepo = join(tmpRoot, 'dotfiles');
+    workspaceRoot = join(tmpRoot, 'workspace');
+    warnings = [];
+
+    await mkdir(join(tmpHome, '.config', 'nvim'), { recursive: true });
+    await mkdir(join(tmpHome, '.obsidian'), { recursive: true });
+    await mkdir(dotfilesRepo, { recursive: true });
+    await mkdir(join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins'), { recursive: true });
+
+    await writeFile(join(tmpHome, '.config', 'nvim', 'init.lua'), '-- nvim\n');
+    await writeFile(join(tmpHome, '.obsidian', 'app.json'), '{}\n');
+    await writeFile(join(tmpHome, '.customrc'), 'set unknown=true\n');
+    await writeFile(join(dotfilesRepo, '.gitconfig'), '[user]\n  name = Test\n');
+    await writeFile(join(workspaceRoot, '.config', 'nvim', 'init.lua'), '-- workspace nvim\n');
+    await writeFile(join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins', 'nested.lua'), '-- nested\n');
+  });
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('maps metadata-declared config and dotfile paths to known tool findings', async () => {
+    const map = await scanDotfileMap({ homeDir: tmpHome, warnings });
+
+    const nvimPath = join(tmpHome, '.config', 'nvim', 'init.lua');
+    const obsidianPath = join(tmpHome, '.obsidian', 'app.json');
+    const nvimFile = fileByPath(map, nvimPath);
+    const obsidianFile = fileByPath(map, obsidianPath);
+
+    expect(nvimFile).toEqual(expect.objectContaining({
+      path: nvimPath,
+      scope: 'home',
+      state: 'known',
+      toolIds: ['neovim'],
+    }));
+    expect(nvimFile?.findings).toEqual([
+      expect.objectContaining({
+        kind: 'metadata-path',
+        classification: 'known',
+        toolIds: ['neovim'],
+        reason: 'config-path',
+        confidence: 'high',
+        safeDetails: expect.objectContaining({
+          matchedPath: '~/.config/nvim',
+          matchType: 'config-path',
+        }),
+      }),
+    ]);
+
+    expect(obsidianFile).toEqual(expect.objectContaining({
+      path: obsidianPath,
+      scope: 'home',
+      state: 'known',
+      toolIds: ['obsidian'],
+    }));
+    expect(obsidianFile?.findings).toEqual([
+      expect.objectContaining({
+        kind: 'metadata-path',
+        classification: 'known',
+        toolIds: ['obsidian'],
+        reason: 'dotfile-path',
+        confidence: 'high',
+        safeDetails: expect.objectContaining({
+          matchedPath: '~/.obsidian',
+          matchType: 'dotfile-path',
+        }),
+      }),
+    ]);
+
+    expect(map.tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        toolId: 'neovim',
+        knownFileCount: 1,
+        findingCount: 1,
+        paths: expect.arrayContaining([nvimPath]),
+      }),
+      expect.objectContaining({
+        toolId: 'obsidian',
+        knownFileCount: 1,
+        findingCount: 1,
+        paths: expect.arrayContaining([obsidianPath]),
+      }),
+    ]));
+    expect(map.counts.knownFiles).toBeGreaterThanOrEqual(2);
+  });
+
+  it('scans home, dotfiles repo, and workspace candidates through bounded allowlists', async () => {
+    const map = await scanDotfileMap({
+      homeDir: tmpHome,
+      dotfilesRepo,
+      workspaceRoots: [workspaceRoot],
+      warnings,
+    });
+
+    expect(fileByPath(map, join(tmpHome, '.customrc'))).toEqual(expect.objectContaining({
+      scope: 'home',
+      state: 'unknown',
+    }));
+    expect(fileByPath(map, join(dotfilesRepo, '.gitconfig'))).toEqual(expect.objectContaining({
+      scope: 'dotfiles-repo',
+      state: 'unknown',
+    }));
+    expect(fileByPath(map, join(workspaceRoot, '.config', 'nvim', 'init.lua'))).toEqual(expect.objectContaining({
+      scope: 'workspace',
+      state: 'known',
+      toolIds: ['neovim'],
+    }));
+    expect(fileByPath(map, join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins', 'nested.lua'))).toBeUndefined();
+  });
+
+  it('counts unknown files separately and treats missing or skipped candidates as non-fatal evidence', async () => {
+    const symlinkPath = join(tmpHome, '.zshrc');
+    await symlink(join(tmpHome, '.customrc'), symlinkPath);
+
+    const map = await scanDotfileMap({
+      homeDir: tmpHome,
+      dotfilesRepo: join(tmpRoot, 'missing-dotfiles'),
+      workspaceRoots: [join(tmpRoot, 'missing-workspace')],
+      warnings,
+    });
+
+    expect(fileByPath(map, join(tmpHome, '.customrc'))).toEqual(expect.objectContaining({
+      state: 'unknown',
+      findings: [
+        expect.objectContaining({
+          kind: 'unknown',
+          classification: 'unknown',
+          toolIds: [],
+          reason: 'unmatched-path',
+        }),
+      ],
+    }));
+    expect(map.counts.unknownFiles).toBeGreaterThanOrEqual(1);
+    expect(fileByPath(map, symlinkPath)).toEqual(expect.objectContaining({
+      state: 'skipped',
+      warningIds: expect.arrayContaining([expect.stringMatching(/^dotfiles-/)]),
+    }));
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        source: 'dotfiles',
+        severity: 'warning',
+        message: expect.stringContaining('Skipped symlink'),
+      }),
+    ]);
+  });
+});

--- a/tests/unit/inventory-dotfiles.test.ts
+++ b/tests/unit/inventory-dotfiles.test.ts
@@ -47,11 +47,15 @@ describe('inventory dotfile scanner', () => {
     await mkdir(join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins'), { recursive: true });
 
     await writeFile(join(tmpHome, '.config', 'nvim', 'init.lua'), '-- nvim\n');
+    await writeFile(join(tmpHome, '.config', 'nvim', '.env.local'), 'TOKEN=secret\n');
     await writeFile(join(tmpHome, '.obsidian', 'app.json'), '{}\n');
     await writeFile(join(tmpHome, '.customrc'), 'set unknown=true\n');
     await writeFile(join(tmpHome, '.zshrc'), rcFixture);
     await writeFile(join(dotfilesRepo, '.gitconfig'), '[user]\n  name = Test\n');
+    await writeFile(join(dotfilesRepo, '.env'), 'SECRET=true\n');
     await writeFile(join(workspaceRoot, '.config', 'nvim', 'init.lua'), '-- workspace nvim\n');
+    await writeFile(join(workspaceRoot, '.config', 'nvim', 'id_rsa.key'), 'private\n');
+    await writeFile(join(workspaceRoot, '.config', 'nvim', 'debug.log'), 'log\n');
     await writeFile(join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins', 'nested.lua'), '-- nested\n');
   });
 
@@ -145,6 +149,10 @@ describe('inventory dotfile scanner', () => {
       state: 'known',
       toolIds: ['neovim'],
     }));
+    expect(fileByPath(map, join(tmpHome, '.config', 'nvim', '.env.local'))).toBeUndefined();
+    expect(fileByPath(map, join(dotfilesRepo, '.env'))).toBeUndefined();
+    expect(fileByPath(map, join(workspaceRoot, '.config', 'nvim', 'id_rsa.key'))).toBeUndefined();
+    expect(fileByPath(map, join(workspaceRoot, '.config', 'nvim', 'debug.log'))).toBeUndefined();
     expect(fileByPath(map, join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins', 'nested.lua'))).toBeUndefined();
   });
 
@@ -182,6 +190,7 @@ describe('inventory dotfile scanner', () => {
         message: expect.stringContaining('Skipped symlink'),
       }),
     ]);
+    expect(warnings[0]?.message).not.toContain(tmpHome);
   });
 
   it('parses shell rc files into safe structured findings without raw values', () => {
@@ -262,6 +271,42 @@ describe('inventory dotfile scanner', () => {
     expect(serialized).not.toContain('op://Personal/item/field');
     expect(serialized).not.toContain('tool command');
     expect(serialized).not.toContain('/opt/homebrew/bin/brew shellenv');
+  });
+
+  it('sanitizes source targets and only recognizes real eval hook forms', () => {
+    const findings = parseShellRcFindings(join(tmpHome, '.zshrc'), [
+      'source ~/.aliases; export TOKEN=plainsecret',
+      '. "$HOME/.profile" && echo "$SECRET"',
+      'source ~/.private # token hint',
+      'source "$(secret command)"',
+      'alias explain="echo run direnv hook zsh"',
+      'echo "brew shellenv"',
+      'eval "$(direnv hook zsh)"',
+    ].join('\n'));
+    const serialized = JSON.stringify(findings);
+
+    expect(findings.filter(finding => finding.kind === 'tool-init-hook')).toEqual([
+      expect.objectContaining({
+        classification: 'known',
+        toolIds: ['direnv'],
+      }),
+    ]);
+    expect(serialized).not.toContain('plainsecret');
+    expect(serialized).not.toContain('echo "$SECRET"');
+    expect(serialized).not.toContain('token hint');
+    expect(serialized).not.toContain('secret command');
+    expect(serialized).not.toContain('echo run direnv hook zsh');
+    expect(serialized).not.toContain('brew shellenv');
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'source',
+        safeDetails: expect.objectContaining({ sourceKind: 'command-derived' }),
+      }),
+      expect.objectContaining({
+        kind: 'source',
+        safeDetails: expect.objectContaining({ sourceKind: 'literal', target: '~/.private' }),
+      }),
+    ]));
   });
 
   it('integrates rc findings into dotfile map counts separately from path findings', async () => {

--- a/tests/unit/inventory-dotfiles.test.ts
+++ b/tests/unit/inventory-dotfiles.test.ts
@@ -3,12 +3,29 @@ import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { scanDotfileMap, type DotfileMap } from '../../src/inventory/dotfiles.js';
+import { parseShellRcFindings, scanDotfileMap, type DotfileMap } from '../../src/inventory/dotfiles.js';
 import type { InventoryWarning } from '../../src/inventory/report.js';
 
 function fileByPath(map: DotfileMap, filePath: string) {
   return map.files.find(file => file.path === filePath);
 }
+
+const rcFixture = [
+  'alias gs="git status"',
+  'function workon() {',
+  '  cd ~/work',
+  '}',
+  'export EDITOR=nvim',
+  'export PATH="$HOME/bin:$PATH"',
+  'export GH_TOKEN=ghp_secret',
+  'export OP_REF=op://Personal/item/field',
+  'export GENERATED="$(tool command)"',
+  'source ~/.aliases',
+  'eval "$(direnv hook zsh)"',
+  'eval "$(vfox activate zsh)"',
+  'eval "$(op signin)"',
+  'eval "$(/opt/homebrew/bin/brew shellenv)"',
+].join('\n');
 
 describe('inventory dotfile scanner', () => {
   let tmpRoot: string;
@@ -32,6 +49,7 @@ describe('inventory dotfile scanner', () => {
     await writeFile(join(tmpHome, '.config', 'nvim', 'init.lua'), '-- nvim\n');
     await writeFile(join(tmpHome, '.obsidian', 'app.json'), '{}\n');
     await writeFile(join(tmpHome, '.customrc'), 'set unknown=true\n');
+    await writeFile(join(tmpHome, '.zshrc'), rcFixture);
     await writeFile(join(dotfilesRepo, '.gitconfig'), '[user]\n  name = Test\n');
     await writeFile(join(workspaceRoot, '.config', 'nvim', 'init.lua'), '-- workspace nvim\n');
     await writeFile(join(workspaceRoot, '.config', 'nvim', 'lua', 'plugins', 'nested.lua'), '-- nested\n');
@@ -131,7 +149,7 @@ describe('inventory dotfile scanner', () => {
   });
 
   it('counts unknown files separately and treats missing or skipped candidates as non-fatal evidence', async () => {
-    const symlinkPath = join(tmpHome, '.zshrc');
+    const symlinkPath = join(tmpHome, '.bashrc');
     await symlink(join(tmpHome, '.customrc'), symlinkPath);
 
     const map = await scanDotfileMap({
@@ -164,5 +182,111 @@ describe('inventory dotfile scanner', () => {
         message: expect.stringContaining('Skipped symlink'),
       }),
     ]);
+  });
+
+  it('parses shell rc files into safe structured findings without raw values', () => {
+    const findings = parseShellRcFindings(join(tmpHome, '.zshrc'), rcFixture);
+    const serialized = JSON.stringify(findings);
+
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'alias',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'gs' }),
+      }),
+      expect.objectContaining({
+        kind: 'function',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'workon' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'EDITOR', valueKind: 'literal' }),
+      }),
+      expect.objectContaining({
+        kind: 'path-edit',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'PATH', valueKind: 'reference' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'GH_TOKEN', valueKind: 'secret-like' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'OP_REF', valueKind: 'secret-like' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'GENERATED', valueKind: 'command-derived' }),
+      }),
+      expect.objectContaining({
+        kind: 'source',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ target: '~/.aliases' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['direnv'],
+        safeDetails: expect.objectContaining({ toolId: 'direnv' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['vfox'],
+        safeDetails: expect.objectContaining({ toolId: 'vfox' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['1password'],
+        safeDetails: expect.objectContaining({ toolId: '1password' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['homebrew'],
+        safeDetails: expect.objectContaining({ toolId: 'homebrew' }),
+      }),
+    ]));
+
+    expect(serialized).not.toContain('git status');
+    expect(serialized).not.toContain('cd ~/work');
+    expect(serialized).not.toContain('nvim');
+    expect(serialized).not.toContain('ghp_secret');
+    expect(serialized).not.toContain('op://Personal/item/field');
+    expect(serialized).not.toContain('tool command');
+    expect(serialized).not.toContain('/opt/homebrew/bin/brew shellenv');
+  });
+
+  it('integrates rc findings into dotfile map counts separately from path findings', async () => {
+    const map = await scanDotfileMap({ homeDir: tmpHome, warnings });
+    const zshrc = fileByPath(map, join(tmpHome, '.zshrc'));
+
+    expect(zshrc).toEqual(expect.objectContaining({
+      state: 'mixed',
+      toolIds: ['1password', 'direnv', 'homebrew', 'vfox'],
+      findings: expect.arrayContaining([
+        expect.objectContaining({ kind: 'alias', classification: 'unknown' }),
+        expect.objectContaining({ kind: 'function', classification: 'unknown' }),
+        expect.objectContaining({ kind: 'source', classification: 'unknown' }),
+        expect.objectContaining({ kind: 'tool-init-hook', classification: 'known', toolIds: ['direnv'] }),
+      ]),
+    }));
+    expect(map.counts).toEqual(expect.objectContaining({
+      knownFindingsCount: 4,
+      unknownFindingsCount: expect.any(Number),
+    }));
+    expect((map.counts as { unknownFindingsCount?: number }).unknownFindingsCount).toBeGreaterThanOrEqual(8);
+
+    const serialized = JSON.stringify(map);
+    expect(serialized).not.toContain('ghp_secret');
+    expect(serialized).not.toContain('op://Personal/item/field');
+    expect(serialized).not.toContain('tool command');
   });
 });

--- a/tests/unit/inventory-scanner.test.ts
+++ b/tests/unit/inventory-scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -54,6 +54,7 @@ vi.mock('../../src/tools/registry.js', () => ({
           formula: 'test-cli',
         },
       },
+      configPaths: ['~/.config/test-cli'],
     },
     {
       id: 'test-editor-installed',
@@ -88,6 +89,22 @@ vi.mock('../../src/tools/registry.js', () => ({
       },
     },
   ],
+  getToolsByConfigPath: (path: string) => path === '~/.config/test-cli' || path.startsWith('~/.config/test-cli/')
+    ? [{
+      id: 'test-cli',
+      label: 'Test CLI',
+      category: 'package-manager',
+      supportedPlatforms: ['darwin'],
+      source: 'first-party',
+      install: {
+        homebrew: {
+          formula: 'test-cli',
+        },
+      },
+      configPaths: ['~/.config/test-cli'],
+    }]
+    : [],
+  getToolsByDotfilePath: () => [],
 }));
 
 vi.mock('node:fs/promises', async () => {
@@ -105,6 +122,9 @@ describe('inventory scanner', () => {
   beforeEach(async () => {
     tmpHome = join(tmpdir(), `tilde-inventory-test-${randomUUID()}`);
     await mkdir(tmpHome, { recursive: true });
+    await mkdir(join(tmpHome, '.config', 'test-cli'), { recursive: true });
+    await writeFile(join(tmpHome, '.config', 'test-cli', 'config.json'), '{}\n');
+    await writeFile(join(tmpHome, '.unknownrc'), 'custom=true\n');
     originalShell = process.env.SHELL;
     process.env.SHELL = '/bin/zsh';
 
@@ -146,6 +166,7 @@ describe('inventory scanner', () => {
       tools: expect.any(Array),
       unmatchedHomebrew: expect.any(Object),
       homebrew: expect.any(Object),
+      dotfiles: expect.any(Object),
       warnings: expect.any(Array),
       environment: expect.any(Object),
     }));
@@ -330,6 +351,34 @@ describe('inventory scanner', () => {
         { type: 'command', command: 'brew', outcome: 'succeeded' },
       ]),
     }));
+  });
+
+  it('attaches a dotfile map and includes concise aggregate dotfile summary output', async () => {
+    const { scanInventory } = await import('../../src/inventory/scan.js');
+    const { summarizeInventory } = await import('../../src/inventory/summary.js');
+
+    const report = await scanInventory(tmpHome);
+    const summary = summarizeInventory(report);
+
+    expect(report.dotfiles).toEqual(expect.objectContaining({
+      files: expect.arrayContaining([
+        expect.objectContaining({
+          path: join(tmpHome, '.config', 'test-cli', 'config.json'),
+          state: 'known',
+          toolIds: ['test-cli'],
+        }),
+        expect.objectContaining({
+          path: join(tmpHome, '.unknownrc'),
+          state: 'unknown',
+        }),
+      ]),
+      counts: expect.objectContaining({
+        knownFiles: 1,
+        unknownFiles: 1,
+      }),
+    }));
+    expect(summary).toContain('Dotfiles: 1 known, 1 unknown, 0 warnings');
+    expect(summary.some(line => line.includes(join(tmpHome, '.unknownrc')))).toBe(false);
   });
 
   it('keeps Homebrew unknown with warning-backed evidence when helper calls fail', async () => {


### PR DESCRIPTION
## Summary

Adds the Phase 03 dotfiles discovery map work on top of the merged machine inventory scanner foundation.

This includes metadata-driven known dotfile path discovery, safe shell rc-file parsing for aliases/env/PATH/source/tool hooks, dotfile summary output, privacy hardening, tests, and GSD verification artifacts.

## Validation

- Phase 03 verification artifacts are included in `.planning/phases/03-dotfiles-discovery-map/`
- Clean stacked branch rebuilt from `origin/main` after Phase 02 squash merge

## Stack

Base PR for the remaining phase stack. Phase 04 should target this branch.