### PR TITLE
[codex] Phase 04 provenance summary

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -29,10 +29,10 @@
 
 ### Provenance Summary
 
-- [ ] **PROV-01**: tilde can label tools as tilde-managed, already installed, Homebrew dependency, manually installed, app-store/manual GUI install, OS-provided, or unknown.
+- [x] **PROV-01**: tilde can label tools as tilde-managed, already installed, Homebrew dependency, manually installed, app-store/manual GUI install, OS-provided, or unknown.
 - [ ] **PROV-02**: Wizard and/or config summary output shows provenance without overwhelming the user.
-- [ ] **PROV-03**: Provenance can explain why tilde selected or skipped a tool.
-- [ ] **PROV-04**: Provenance data is derived from scanner output and metadata rather than hardcoded per-step text.
+- [x] **PROV-03**: Provenance can explain why tilde selected or skipped a tool.
+- [x] **PROV-04**: Provenance data is derived from scanner output and metadata rather than hardcoded per-step text.
 
 ### Config Discovery
 
@@ -87,10 +87,10 @@
 | DOT-02 | Phase 3 | Complete |
 | DOT-03 | Phase 3 | Complete |
 | DOT-04 | Phase 3 | Complete |
-| PROV-01 | Phase 4 | Pending |
+| PROV-01 | Phase 4 | Complete |
 | PROV-02 | Phase 4 | Pending |
-| PROV-03 | Phase 4 | Pending |
-| PROV-04 | Phase 4 | Pending |
+| PROV-03 | Phase 4 | Complete |
+| PROV-04 | Phase 4 | Complete |
 | CONF-01 | Phase 5 | Pending |
 | CONF-02 | Phase 5 | Pending |
 | CONF-03 | Phase 5 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -30,7 +30,7 @@
 ### Provenance Summary
 
 - [x] **PROV-01**: tilde can label tools as tilde-managed, already installed, Homebrew dependency, manually installed, app-store/manual GUI install, OS-provided, or unknown.
-- [ ] **PROV-02**: Wizard and/or config summary output shows provenance without overwhelming the user.
+- [x] **PROV-02**: Wizard and/or config summary output shows provenance without overwhelming the user.
 - [x] **PROV-03**: Provenance can explain why tilde selected or skipped a tool.
 - [x] **PROV-04**: Provenance data is derived from scanner output and metadata rather than hardcoded per-step text.
 
@@ -88,7 +88,7 @@
 | DOT-03 | Phase 3 | Complete |
 | DOT-04 | Phase 3 | Complete |
 | PROV-01 | Phase 4 | Complete |
-| PROV-02 | Phase 4 | Pending |
+| PROV-02 | Phase 4 | Complete |
 | PROV-03 | Phase 4 | Complete |
 | PROV-04 | Phase 4 | Complete |
 | CONF-01 | Phase 5 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -167,5 +167,5 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
 | 1. Tool Metadata Registry | 3/3 | Complete    | 2026-06-13 |
 | 2. Machine Inventory Scanner | 7/7 | Complete   | 2026-06-14 |
 | 3. Dotfiles Discovery Map | 2/2 | Complete    | 2026-06-19 |
-| 4. Provenance Summary | 2/2 | Complete   | 2026-06-20 |
+| 4. Provenance Summary | 2/2 | Complete    | 2026-06-20 |
 | 5. Config Discovery Polish | 0/1 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -14,7 +14,7 @@ This roadmap turns tilde from a setup wizard into a machine-aware setup assistan
 - [x] **Phase 1: Tool Metadata Registry** - Create the shared data model and registry lookup layer for wizard tool metadata. (completed 2026-06-13)
 - [x] **Phase 2: Machine Inventory Scanner** - Detect installed tools and Homebrew direct-vs-dependency provenance. (completed 2026-06-13)
 - [x] **Phase 3: Dotfiles Discovery Map** - Map known dotfiles and rc-file contents to tools. (completed 2026-06-19)
-- [ ] **Phase 4: Provenance Summary** - Surface clear managed/already-installed/dependency/manual/unknown status to users.
+- [x] **Phase 4: Provenance Summary** - Surface clear managed/already-installed/dependency/manual/unknown status to users. (completed 2026-06-20)
 - [ ] **Phase 5: Config Discovery Polish** - Improve non-default config discovery and error messaging.
 
 ## Phase Details
@@ -136,7 +136,7 @@ Plans:
 
 **Wave 2 (blocked on Wave 1 completion)**
 
-- [ ] 04-02-PLAN.md - Render provenance in wizard/config summary output.
+- [x] 04-02-PLAN.md - Render provenance in wizard/config summary output.
 
 ### Phase 5: Config Discovery Polish
 
@@ -167,5 +167,5 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
 | 1. Tool Metadata Registry | 3/3 | Complete    | 2026-06-13 |
 | 2. Machine Inventory Scanner | 7/7 | Complete   | 2026-06-14 |
 | 3. Dotfiles Discovery Map | 2/2 | Complete    | 2026-06-19 |
-| 4. Provenance Summary | 1/2 | In Progress|  |
+| 4. Provenance Summary | 2/2 | Complete   | 2026-06-20 |
 | 5. Config Discovery Polish | 0/1 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -130,8 +130,13 @@ Plans:
 
 Plans:
 
-- [ ] 04-01: Define provenance categories and derivation rules.
-- [ ] 04-02: Render provenance in wizard/config summary output.
+**Wave 1**
+
+- [ ] 04-01-PLAN.md - Define provenance categories and derivation rules.
+
+**Wave 2 (blocked on Wave 1 completion)**
+
+- [ ] 04-02-PLAN.md - Render provenance in wizard/config summary output.
 
 ### Phase 5: Config Discovery Polish
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -132,7 +132,7 @@ Plans:
 
 **Wave 1**
 
-- [ ] 04-01-PLAN.md - Define provenance categories and derivation rules.
+- [x] 04-01-PLAN.md - Define provenance categories and derivation rules.
 
 **Wave 2 (blocked on Wave 1 completion)**
 
@@ -167,5 +167,5 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5
 | 1. Tool Metadata Registry | 3/3 | Complete    | 2026-06-13 |
 | 2. Machine Inventory Scanner | 7/7 | Complete   | 2026-06-14 |
 | 3. Dotfiles Discovery Map | 2/2 | Complete    | 2026-06-19 |
-| 4. Provenance Summary | 0/2 | Not started | - |
+| 4. Provenance Summary | 1/2 | In Progress|  |
 | 5. Config Discovery Polish | 0/1 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: verifying
+status: completed
 stopped_at: Completed 04-02-PLAN.md
-last_updated: "2026-06-20T01:12:46.710Z"
-last_activity: 2026-06-20 -- Phase 04 execution started
+last_updated: "2026-06-20T01:15:46.834Z"
+last_activity: 2026-06-20 -- Phase 04 marked complete
 progress:
   total_phases: 5
   completed_phases: 4
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-06-12)
 
 ## Current Position
 
-Phase: 04 (provenance-summary) — EXECUTING
-Plan: 2 of 2
-Status: Phase complete — ready for verification
-Last activity: 2026-06-20 -- Phase 04 execution started
+Phase: 04 — COMPLETE
+Plan: Not started
+Status: Phase 04 complete
+Last activity: 2026-06-20 -- Phase 04 marked complete
 
 Progress: [██████░░░░] 60%
 
@@ -36,7 +36,7 @@ Progress: [██████░░░░] 60%
 
 **Velocity:**
 
-- Total plans completed: 14
+- Total plans completed: 16
 - Average duration: 17 min
 - Total execution time: 50 min
 
@@ -46,6 +46,7 @@ Progress: [██████░░░░] 60%
 |-------|-------|-------|----------|
 | 01 | 3 | 50 min | 17 min |
 | 03 | 2 | - | - |
+| 04 | 2 | - | - |
 
 **Recent Trend:**
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: executing
-stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-06-20T01:09:24.675Z"
+status: verifying
+stopped_at: Completed 04-02-PLAN.md
+last_updated: "2026-06-20T01:12:46.710Z"
 last_activity: 2026-06-20 -- Phase 04 execution started
 progress:
   total_phases: 5
-  completed_phases: 3
+  completed_phases: 4
   total_plans: 14
-  completed_plans: 13
-  percent: 60
+  completed_plans: 14
+  percent: 80
 ---
 
 # Project State
@@ -27,7 +27,7 @@ See: .planning/PROJECT.md (updated 2026-06-12)
 
 Phase: 04 (provenance-summary) — EXECUTING
 Plan: 2 of 2
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-06-20 -- Phase 04 execution started
 
 Progress: [██████░░░░] 60%
@@ -60,6 +60,7 @@ Progress: [██████░░░░] 60%
 | Phase 02 P06 | 36min | 3 tasks | 7 files |
 | Phase 03 P02 | 17min | 2 tasks | 5 files |
 | Phase 04 P01 | 6 min | 2 tasks | 2 files |
+| Phase 04 P02 | 4 min | 2 tasks | 7 files |
 
 ## Accumulated Context
 
@@ -103,6 +104,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-20T01:09:24.665Z
-Stopped at: Completed 04-01-PLAN.md
+Last session: 2026-06-20T01:12:46.707Z
+Stopped at: Completed 04-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: Ready for next phase
-stopped_at: Completed 03-02-PLAN.md
-last_updated: "2026-06-19T22:56:18.841Z"
-last_activity: 2026-06-19
+status: executing
+stopped_at: Completed 04-01-PLAN.md
+last_updated: "2026-06-20T01:09:24.675Z"
+last_activity: 2026-06-20 -- Phase 04 execution started
 progress:
   total_phases: 5
   completed_phases: 3
-  total_plans: 12
-  completed_plans: 12
+  total_plans: 14
+  completed_plans: 13
   percent: 60
 ---
 
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-12)
 
 **Core value:** tilde should explain a machine's developer setup clearly enough that users can trust what it will manage before it changes anything.
-**Current focus:** Phase 03 — dotfiles-discovery-map
+**Current focus:** Phase 04 — provenance-summary
 
 ## Current Position
 
-Phase: 4
-Plan: Not started
-Status: Ready for next phase
-Last activity: 2026-06-19
+Phase: 04 (provenance-summary) — EXECUTING
+Plan: 2 of 2
+Status: Ready to execute
+Last activity: 2026-06-20 -- Phase 04 execution started
 
 Progress: [██████░░░░] 60%
 
@@ -59,6 +59,7 @@ Progress: [██████░░░░] 60%
 | Phase 02 P05 | 9min | 2 tasks | 6 files |
 | Phase 02 P06 | 36min | 3 tasks | 7 files |
 | Phase 03 P02 | 17min | 2 tasks | 5 files |
+| Phase 04 P01 | 6 min | 2 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -102,6 +103,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-19T22:18:16.820Z
-Stopped at: Completed 03-02-PLAN.md
+Last session: 2026-06-20T01:09:24.665Z
+Stopped at: Completed 04-01-PLAN.md
 Resume file: None

--- a/.planning/phases/04-provenance-summary/04-01-PLAN.md
+++ b/.planning/phases/04-provenance-summary/04-01-PLAN.md
@@ -136,6 +136,7 @@ Output: `src/inventory/provenance.ts` exports and `tests/unit/inventory-provenan
   <files>src/inventory/provenance.ts, tests/unit/inventory-provenance.test.ts</files>
   <read_first>
     - `src/inventory/provenance.ts` — keep useful partial exports but correct category names and precedence.
+    - `src/inventory/scan.ts` — scanner-owned shell/core-tool evidence and warning patterns from `04-PATTERNS.md`.
     - `tests/unit/inventory-provenance.test.ts` — RED contract from Task 1.
     - `.planning/phases/04-provenance-summary/04-RESEARCH.md` — pitfalls for selected precedence, arbitrary `config.tools`, metadata-driven manual labels, and unknown selected tools.
     - `.planning/phases/02-machine-inventory-scanner/02-04-SUMMARY.md` — Homebrew direct/dependency evidence is request status, not final provenance by itself.

--- a/.planning/phases/04-provenance-summary/04-01-PLAN.md
+++ b/.planning/phases/04-provenance-summary/04-01-PLAN.md
@@ -1,0 +1,202 @@
+---
+phase: 04-provenance-summary
+plan: 1
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/inventory/provenance.ts
+  - tests/unit/inventory-provenance.test.ts
+autonomous: true
+requirements:
+  - PROV-01
+  - PROV-03
+  - PROV-04
+user_setup: []
+must_haves:
+  truths:
+    - "PROV-01: Users can distinguish tilde-managed, already installed, Homebrew dependency, manual install, manual GUI/App Store, OS-provided, and unknown tool provenance."
+    - "PROV-03: Selected tools keep tilde-managed as the primary label while detail/action text explains installed, dependency, manual, or unknown evidence."
+    - "PROV-04: Provenance is derived from TildeConfig intent, InventoryReport evidence, and tool metadata, not UI-specific text."
+  artifacts:
+    - path: "src/inventory/provenance.ts"
+      provides: "Shared provenance derivation, grouping, formatting, detail, and action explanations"
+      exports: ["deriveInventoryProvenance", "summarizeProvenanceGroups", "formatProvenanceSummaryLine"]
+    - path: "tests/unit/inventory-provenance.test.ts"
+      provides: "Unit coverage for provenance precedence, categories, grouping, warnings, and unknown paths"
+  key_links:
+    - from: "src/inventory/provenance.ts"
+      to: "src/tools/registry.ts"
+      via: "getToolMetadata"
+      pattern: "getToolMetadata"
+    - from: "src/inventory/provenance.ts"
+      to: "src/config/schema.ts"
+      via: "TildeConfig selected ids"
+      pattern: "packageManagers|versionManagers|browser|editors|aiTools"
+---
+
+## Phase Goal
+
+**As a** tilde user, **I want to** see each tool's provenance category in setup summaries, **so that** I can trust what tilde will manage before it changes anything.
+
+<objective>
+Define the shared provenance categories, precedence rules, grouping, and action explanations for Phase 04.
+
+Purpose: Establish one tested derivation layer for PROV-01, PROV-03, and PROV-04 before any UI rendering depends on it.
+Output: `src/inventory/provenance.ts` exports and `tests/unit/inventory-provenance.test.ts`.
+</objective>
+
+<execution_context>
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/workflows/execute-plan.md
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/04-provenance-summary/04-CONTEXT.md
+@.planning/phases/04-provenance-summary/04-RESEARCH.md
+@.planning/phases/04-provenance-summary/04-PATTERNS.md
+@.planning/phases/04-provenance-summary/04-VALIDATION.md
+@.planning/phases/02-machine-inventory-scanner/02-04-SUMMARY.md
+@.planning/phases/02-machine-inventory-scanner/02-07-SUMMARY.md
+@.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md
+
+@src/inventory/provenance.ts
+@src/inventory/report.ts
+@src/inventory/summary.ts
+@src/tools/metadata.ts
+@src/tools/registry.ts
+@src/config/schema.ts
+@tests/unit/inventory-scanner.test.ts
+</context>
+
+## Artifacts This Phase Produces
+
+- `src/inventory/provenance.ts`: shared provenance types and functions: `ProvenanceLabel`, `ToolProvenance`, `deriveInventoryProvenance()`, `summarizeProvenanceGroups()`, and `formatProvenanceSummaryLine()`.
+- `tests/unit/inventory-provenance.test.ts`: derivation and formatting coverage for PROV-01, PROV-03, and PROV-04.
+- Phase 04 also produces shared rendering coverage in Plan 04-02.
+
+## Source Audit
+
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|---|---|---|---|---|---|
+| GOAL | - | Users can see managed, installed, dependency, manual, OS-provided, and unknown provenance. | 04-01, 04-02 | COVERED | 04-01 defines categories; 04-02 renders them. |
+| REQ | PROV-01 | Label tools with required provenance categories. | 04-01 | COVERED | Primary category union and tests live here. |
+| REQ | PROV-03 | Explain selected/skipped tool actions. | 04-01, 04-02 | COVERED | Derivation returns action text; UI renders shared summary. |
+| REQ | PROV-04 | Derive from scanner and metadata, not per-step text. | 04-01, 04-02 | COVERED | Helper consumes `InventoryReport`, `TildeConfig`, and metadata. |
+| RESEARCH | - | Do not expose `homebrew-direct` as a user-facing primary provenance category. | 04-01 | COVERED | Direct Homebrew stays in detail for already installed tools. |
+| RESEARCH | - | Keep unknown selected tools non-blocking with cautious action text. | 04-01 | COVERED | Unit tests assert action text and no blocking state. |
+| CONTEXT | D-01 | `tilde-managed` means selected by current config or wizard run. | 04-01 | COVERED | Selected ids take first precedence. |
+| CONTEXT | D-02 | Selected and already installed keeps primary `tilde-managed`; detail preserves evidence. | 04-01 | COVERED | Unit tests assert selected direct and dependency cases. |
+| CONTEXT | D-03 | Homebrew dependency remains explicit evidence and detail. | 04-01 | COVERED | `homebrew-dependency` is a primary group for unselected dependency facts and detail for selected facts. |
+| CONTEXT | D-04 | Manual, App Store, and manual GUI labels are metadata-driven. | 04-01 | COVERED | Metadata `install.manualNote` and `install.appPath` drive manual categories. |
+| CONTEXT | D-05 | OS-provided applies only to scanner-owned core tools and shells. | 04-01 | COVERED | Classifier checks `shell:`/`core-tool:` ids plus scanner evidence. |
+| CONTEXT | D-06 | `unknown` means insufficient or inconclusive evidence. | 04-01 | COVERED | Unknown action/detail coverage included. |
+| CONTEXT | D-07 | Add shared helper separate from UI components. | 04-01 | COVERED | Helper remains under `src/inventory/`. |
+| CONTEXT | D-08 | Preserve structured evidence for tests and future audit views; no verbose audit UI. | 04-01, 04-02 | COVERED | `ToolProvenance.evidence` and `warningIds` remain structured. |
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Lock provenance precedence and category behavior in unit tests</name>
+  <files>tests/unit/inventory-provenance.test.ts</files>
+  <read_first>
+    - `src/inventory/provenance.ts` — interrupted partial helper to reconcile.
+    - `src/inventory/report.ts` — `InventoryReport`, evidence, warnings, and scanner-owned category contracts.
+    - `src/config/schema.ts` — selected config fields for package managers, version managers, tools, browsers, editors, and AI tools.
+    - `src/tools/metadata.ts` and `src/tools/registry.ts` — metadata fields and lookup helper.
+    - `tests/unit/inventory-scanner.test.ts` — fixture and assertion style with mocked scanner data.
+    - `.planning/phases/04-provenance-summary/04-CONTEXT.md` — locked D-01 through D-08 provenance semantics.
+  </read_first>
+  <behavior>
+    - Test D-01/D-02: selected tools from config produce primary `tilde-managed`, including selected tools already installed as direct Homebrew, Homebrew dependency, app-path, and command evidence.
+    - Test D-03: unselected Homebrew formula dependency facts produce a `homebrew-dependency` provenance group and preserve dependency detail.
+    - Test D-04: metadata-backed manual/app bundle evidence produces manual install or manual GUI/App Store provenance without hardcoded UI maps.
+    - Test D-05: only scanner-owned `shell:*` and `core-tool:*` installed facts with scanner evidence produce `os-provided`; arbitrary unknown selected ids do not.
+    - Test D-06: inconclusive or missing evidence produces `unknown` with warning ids preserved and action text that does not block apply.
+    - Test D-08: grouped summaries show at most 3 examples per group and `+N more`, while detailed evidence remains structured on `ToolProvenance`.
+  </behavior>
+  <action>Create `tests/unit/inventory-provenance.test.ts` with direct `InventoryReport` fixtures and metadata registry mocks where metadata-specific branches need isolation. Assert the user-facing `ProvenanceLabel` values required by PROV-01: `tilde-managed`, `already-installed`, `homebrew-dependency`, `manual-install`, `manual-gui`, `os-provided`, and `unknown`. Do not call real `brew`, `gh`, `op`, `vfox`, `defaultbrowser`, filesystem scanners, or installer code. Reference D-01 through D-08 in test names or comments only where it helps trace behavior.</action>
+  <verify>
+    <automated>npm run test -- tests/unit/inventory-provenance.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - The new test file exists and fails before Task 2 because current provenance semantics still expose `homebrew-direct` and over-broad OS-provided classification.
+    - The tests cover PROV-01 category coverage, PROV-03 action explanation behavior, and PROV-04 derivation from fixtures plus metadata.
+    - The tests use fixture reports or mocks only; no external command helpers are invoked.
+  </acceptance_criteria>
+  <done>RED tests define the complete provenance derivation contract for Plan 04-01 without adding UI rendering.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement shared provenance derivation and summary grouping</name>
+  <files>src/inventory/provenance.ts, tests/unit/inventory-provenance.test.ts</files>
+  <read_first>
+    - `src/inventory/provenance.ts` — keep useful partial exports but correct category names and precedence.
+    - `tests/unit/inventory-provenance.test.ts` — RED contract from Task 1.
+    - `.planning/phases/04-provenance-summary/04-RESEARCH.md` — pitfalls for selected precedence, arbitrary `config.tools`, metadata-driven manual labels, and unknown selected tools.
+    - `.planning/phases/02-machine-inventory-scanner/02-04-SUMMARY.md` — Homebrew direct/dependency evidence is request status, not final provenance by itself.
+    - `.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md` — no raw rc values or verbose audit output in default summaries.
+  </read_first>
+  <behavior>
+    - `deriveInventoryProvenance(report, config?)` returns one `ToolProvenance` per scanner fact plus synthetic selected records for config-selected ids missing from the report.
+    - Selected ids from `packageManagers`, `versionManagers[].name`, `tools`, `browser.selected`, `browser.default`, `editors.primary`, `editors.additional`, and `aiTools[].name` take primary `tilde-managed` precedence per D-01/D-02.
+    - Homebrew direct evidence for unselected installed tools displays as `already-installed`; direct/dependency/cask evidence remains in `detail`.
+    - Unselected Homebrew dependency evidence displays as `homebrew-dependency` and is not collapsed into already-installed.
+    - Metadata `install.manualNote` and `install.appPath` drive `manual-install` or `manual-gui` categories when evidence supports that path; inconclusive unselected manual metadata remains `unknown` with useful detail.
+    - OS-provided applies only to installed scanner-owned `shell:*` and `core-tool:*` facts with shell or command evidence, not every `core-tool` category fallback.
+  </behavior>
+  <action>Reconcile the interrupted `src/inventory/provenance.ts` implementation instead of replacing it blindly. Rename the primary provenance union away from `homebrew-direct` and `unmanaged` into the PROV-01 categories, keep the existing exported function names where tests and Plan 04-02 will use them, preserve `evidence` and `warningIds` on every `ToolProvenance`, and keep `formatProvenanceSummaryLine(report, config?)` concise with grouped counts, up to 3 examples, and `+N more`. Do not add a scanner, installer behavior, external command call, verbose audit UI, or per-step provenance maps.</action>
+  <verify>
+    <automated>npm run test -- tests/unit/inventory-provenance.test.ts</automated>
+    <automated>npm run build</automated>
+  </verify>
+  <acceptance_criteria>
+    - `npm run test -- tests/unit/inventory-provenance.test.ts` passes with all RED cases from Task 1.
+    - `formatProvenanceSummaryLine()` returns one line beginning `Provenance:` and never dumps raw rc/source/env details.
+    - `deriveInventoryProvenance()` uses `InventoryReport`, optional `TildeConfig`, and `getToolMetadata()`; no UI components import into the helper.
+    - Existing interrupted edits are reconciled, not reset; unrelated workspace changes remain untouched.
+  </acceptance_criteria>
+  <done>Shared provenance derivation is implemented, tested, and ready for shared rendering in Plan 04-02.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|---|---|
+| `InventoryReport` -> provenance helper | Scanner evidence and warning data become user-visible trust summaries. |
+| `TildeConfig` -> provenance helper | User/config-selected ids affect primary labels and action explanations. |
+| metadata registry -> provenance helper | Static metadata affects manual/App Store/manual GUI labels. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|---|---|---|---|---|
+| T-04-01 | Information Disclosure | `formatProvenanceSummaryLine()` | mitigate | Keep default output to counts, labels, examples, and safe action/detail text; unit tests assert raw rc/source/env details are not printed. |
+| T-04-02 | Tampering | `deriveInventoryProvenance()` precedence | mitigate | Unit-test selected precedence, Homebrew dependency handling, and scanner-owned OS-provided rules. |
+| T-04-03 | Denial of Service | unknown selected tool handling | mitigate | Unknown selected tools return cautious action text and do not introduce blocking state. |
+| T-04-SC | Tampering | npm/pip/cargo installs | accept | No package-manager install tasks exist in this plan; no package legitimacy checkpoint is required. |
+</threat_model>
+
+<verification>
+Run targeted unit and build checks after implementation:
+- `npm run test -- tests/unit/inventory-provenance.test.ts`
+- `npm run build`
+</verification>
+
+<success_criteria>
+- PROV-01 categories are represented by tested user-facing labels.
+- PROV-03 action explanations exist for install, skip present, dependency-present, leave unmanaged, and cautious unknown paths.
+- PROV-04 derivation stays in `src/inventory/provenance.ts` and consumes scanner evidence plus metadata.
+- No verbose audit UI or new scanner behavior is introduced.
+</success_criteria>
+
+<output>
+Create `.planning/phases/04-provenance-summary/04-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/04-provenance-summary/04-01-SUMMARY.md
+++ b/.planning/phases/04-provenance-summary/04-01-SUMMARY.md
@@ -1,0 +1,98 @@
+---
+phase: 04-provenance-summary
+plan: 1
+subsystem: inventory
+tags: [provenance, inventory, metadata, vitest]
+requires:
+  - phase: 02-machine-inventory-scanner
+    provides: InventoryReport evidence, Homebrew request status, app-path facts, scanner-owned shell/core-tool facts
+  - phase: 03-dotfiles-discovery-map
+    provides: Concise inventory summary constraints and warning preservation
+provides:
+  - Shared provenance derivation helper for inventory facts, config intent, and tool metadata
+  - User-facing provenance grouping and summary formatting
+  - Unit coverage for selected precedence, Homebrew dependency handling, manual GUI labels, OS-provided rules, and unknown paths
+affects: [inventory-summary, config-first, wizard-confirmation]
+tech-stack:
+  added: []
+  patterns:
+    - Evidence-first inventory derivation with structured detail preserved for future audit views
+key-files:
+  created:
+    - tests/unit/inventory-provenance.test.ts
+  modified:
+    - src/inventory/provenance.ts
+key-decisions:
+  - "Primary provenance labels use PROV-01 user-facing categories; Homebrew direct remains detail under already-installed."
+  - "OS-provided is limited to scanner-owned shell:* and core-tool:* installed facts with shell or command evidence."
+  - "Selected tools keep tilde-managed as primary while action/detail text explains installed, dependency, manual, or unknown evidence."
+patterns-established:
+  - "deriveInventoryProvenance(report, config?) is the shared classifier boundary for UI surfaces."
+  - "formatProvenanceSummaryLine() emits one concise grouped line with at most three examples per group."
+requirements-completed: [PROV-01, PROV-03, PROV-04]
+duration: 6 min
+completed: 2026-06-20
+---
+
+# Phase 04 Plan 01: Provenance Categories Summary
+
+**Evidence-backed provenance derivation with config-aware tilde-managed precedence and concise grouped formatting**
+
+## Performance
+
+- **Duration:** 6 min
+- **Started:** 2026-06-20T01:02:00Z
+- **Completed:** 2026-06-20T01:08:46Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+
+- Added unit coverage for PROV-01 categories, PROV-03 action text, and PROV-04 shared derivation from inventory/config/metadata.
+- Reconciled the interrupted provenance helper to use `already-installed`, `homebrew-dependency`, `manual-install`, `manual-gui`, `os-provided`, `tilde-managed`, and `unknown`.
+- Preserved structured `evidence` and `warningIds` while keeping `formatProvenanceSummaryLine()` concise.
+
+## Task Commits
+
+1. **Task 1 and Task 2: Provenance contract and implementation** - `2bb1a61` (test)
+
+**Plan metadata:** pending docs commit
+
+## Files Created/Modified
+
+- `src/inventory/provenance.ts` - Shared provenance derivation, grouping, detail/action text, and summary line formatting.
+- `tests/unit/inventory-provenance.test.ts` - Unit coverage for precedence, categories, grouping, warning preservation, and unknown selected paths.
+
+## Decisions Made
+
+- Homebrew direct is not a primary user-facing label; it appears as detail for `already-installed` or `tilde-managed` records.
+- OS-provided classification requires scanner-owned ids and concrete shell/command evidence, avoiding broad `core-tool` fallback labels.
+- Unknown selected tools remain non-blocking and return cautious action text.
+
+## Deviations from Plan
+
+The two TDD tasks were committed together because the interrupted helper already existed untracked and the contract plus implementation were reconciled in one local pass. The RED run was still performed and failed before the helper patch, then passed after implementation.
+
+**Total deviations:** 1 procedural deviation.
+**Impact on plan:** Behavioral scope stayed within Plan 04-01; verification passed.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Verification
+
+- `npm run test -- tests/unit/inventory-provenance.test.ts` - passed
+- `npm run build` - passed
+
+## Next Phase Readiness
+
+Plan 04-02 can now render shared provenance output through `summarizeInventory(report, config?)` in config-first and wizard confirmation paths.
+
+---
+*Phase: 04-provenance-summary*
+*Completed: 2026-06-20*

--- a/.planning/phases/04-provenance-summary/04-02-PLAN.md
+++ b/.planning/phases/04-provenance-summary/04-02-PLAN.md
@@ -1,0 +1,231 @@
+---
+phase: 04-provenance-summary
+plan: 2
+type: execute
+wave: 2
+depends_on:
+  - "04-01"
+files_modified:
+  - src/inventory/summary.ts
+  - src/modes/config-first.tsx
+  - src/modes/wizard.tsx
+  - src/steps/apply.tsx
+  - tests/integration/config-first.test.ts
+  - tests/integration/wizard-flow.test.tsx
+autonomous: true
+requirements:
+  - PROV-01
+  - PROV-02
+  - PROV-03
+  - PROV-04
+user_setup: []
+must_haves:
+  truths:
+    - "PROV-02: Wizard and config-first output show one concise grouped provenance line without verbose audit details."
+    - "PROV-03: Config-aware summaries explain selected/skipped tool outcomes at points where a complete TildeConfig exists."
+    - "PROV-04: UI components render shared summary lines and do not duplicate provenance derivation logic."
+  artifacts:
+    - path: "src/inventory/summary.ts"
+      provides: "Shared inventory summary including provenance line"
+      exports: ["summarizeInventory", "getInstalledKnownToolFacts"]
+    - path: "src/modes/config-first.tsx"
+      provides: "Config-first confirmation rendering with config-aware provenance"
+    - path: "src/steps/apply.tsx"
+      provides: "Final wizard confirmation rendering with config-aware provenance"
+    - path: "src/modes/wizard.tsx"
+      provides: "InventoryReport pass-through to final wizard confirmation"
+    - path: "tests/integration/config-first.test.ts"
+      provides: "Config-first shared provenance summary coverage"
+    - path: "tests/integration/wizard-flow.test.tsx"
+      provides: "Wizard shared provenance summary and warning-path coverage"
+  key_links:
+    - from: "src/inventory/summary.ts"
+      to: "src/inventory/provenance.ts"
+      via: "formatProvenanceSummaryLine(report, config?)"
+      pattern: "formatProvenanceSummaryLine"
+    - from: "src/modes/config-first.tsx"
+      to: "src/inventory/summary.ts"
+      via: "summarizeInventory(inventoryReport, phase.config)"
+      pattern: "summarizeInventory\\(inventoryReport, phase\\.config\\)"
+    - from: "src/modes/wizard.tsx"
+      to: "src/steps/apply.tsx"
+      via: "inventory prop"
+      pattern: "inventory=\\{inventoryReport\\}"
+---
+
+## Phase Goal
+
+**As a** tilde user, **I want to** see each tool's provenance category in setup summaries, **so that** I can trust what tilde will manage before it changes anything.
+
+<objective>
+Render the shared provenance summary in config-first and wizard confirmation output while keeping normal terminal output concise.
+
+Purpose: Complete PROV-02 and surface the Plan 04-01 derivation through the existing shared summary path without per-step provenance text.
+Output: Shared summary wiring and integration tests for config-first, early wizard inventory, final wizard confirmation, unknown paths, and warnings.
+</objective>
+
+<execution_context>
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/workflows/execute-plan.md
+@/Users/jeff.williams/Developer/personal/tilde/.codex/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/04-provenance-summary/04-CONTEXT.md
+@.planning/phases/04-provenance-summary/04-RESEARCH.md
+@.planning/phases/04-provenance-summary/04-PATTERNS.md
+@.planning/phases/04-provenance-summary/04-VALIDATION.md
+@.planning/phases/04-provenance-summary/04-01-SUMMARY.md
+@.planning/phases/02-machine-inventory-scanner/02-05-SUMMARY.md
+@.planning/phases/02-machine-inventory-scanner/02-06-SUMMARY.md
+@.planning/phases/03-dotfiles-discovery-map/03-02-SUMMARY.md
+
+@src/inventory/provenance.ts
+@src/inventory/summary.ts
+@src/steps/inventory.tsx
+@src/steps/apply.tsx
+@src/modes/config-first.tsx
+@src/modes/wizard.tsx
+@tests/integration/config-first.test.ts
+@tests/integration/wizard-flow.test.tsx
+</context>
+
+## Artifacts This Phase Produces
+
+- `src/inventory/summary.ts`: shared `summarizeInventory(report, config?)` output including exactly one concise `Provenance:` line.
+- `src/modes/config-first.tsx`: config-first confirmation passes complete `TildeConfig` into summary output.
+- `src/steps/apply.tsx`: final wizard confirmation can render config-aware inventory provenance before apply choices.
+- `src/modes/wizard.tsx`: wizard passes the startup `InventoryReport` into final confirmation while keeping the early inventory step evidence-only.
+- Integration tests in `tests/integration/config-first.test.ts` and `tests/integration/wizard-flow.test.tsx`.
+
+## Source Audit
+
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|---|---|---|---|---|---|
+| GOAL | - | Users can see provenance categories in normal setup summaries. | 04-02 | COVERED | Shared summary line renders in config-first and wizard output. |
+| REQ | PROV-01 | Required categories are visible to users. | 04-01, 04-02 | COVERED | 04-02 asserts rendered category names from 04-01. |
+| REQ | PROV-02 | Provenance appears without overwhelming the user. | 04-02 | COVERED | One line, grouped counts, up to 3 examples, `+N more`. |
+| REQ | PROV-03 | Explain why tilde selected or skipped a tool. | 04-01, 04-02 | COVERED | Config-aware output appears where complete config exists. |
+| REQ | PROV-04 | Provenance derives from scanner output and metadata. | 04-01, 04-02 | COVERED | UI renders `summarizeInventory()` only. |
+| RESEARCH | - | Early wizard inventory cannot know final selections. | 04-02 | COVERED | Early step remains evidence-oriented; final `ApplyStep` gets config-aware provenance. |
+| RESEARCH | - | Existing config-first partial edit already passes config to summary. | 04-02 | COVERED | Executor reconciles and tests current partial source, not reset. |
+| CONTEXT | D-09 | Normal output is one provenance summary line with grouped counts, up to 3 examples, and `+N more`. | 04-02 | COVERED | Integration tests assert one concise line and no verbose evidence. |
+| CONTEXT | D-10 | Use shared summary output in wizard inventory and config-first confirmation. | 04-02 | COVERED | Both UI paths render `summarizeInventory()`. |
+| CONTEXT | D-11 | Explanations are action-oriented. | 04-01, 04-02 | COVERED | Derived actions are shown through config-aware summary surfaces. |
+| CONTEXT | D-12 | Selected dependency-installed tools read as selected and already present as dependency. | 04-01, 04-02 | COVERED | Config-aware tests assert `tilde-managed` with dependency detail/grouping behavior. |
+| CONTEXT | D-13 | Unknown selected tools do not block apply; warnings are preserved. | 04-01, 04-02 | COVERED | Failed/unknown report tests keep apply choices visible and warning lines present. |
+| CONTEXT | Deferred | Verbose audit view. | NONE | EXCLUDED | Explicitly deferred; no plan adds it. |
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add shared summary rendering regression tests</name>
+  <files>tests/integration/config-first.test.ts, tests/integration/wizard-flow.test.tsx</files>
+  <read_first>
+    - `tests/integration/config-first.test.ts` — existing inventory-before-config fixture and warning assertions.
+    - `tests/integration/wizard-flow.test.tsx` — existing wizard inventory fixture and loading/failure assertions.
+    - `src/inventory/summary.ts` — shared output order and warning grouping.
+    - `src/steps/inventory.tsx` — early wizard inventory rendering without final config.
+    - `src/steps/apply.tsx` — final wizard confirmation point with complete config.
+    - `src/modes/config-first.tsx` — config-first confirmation path and interrupted partial edit.
+    - `.planning/phases/04-provenance-summary/04-RESEARCH.md` — open question on config-aware wizard rendering.
+  </read_first>
+  <behavior>
+    - Config-first confirmation renders one `Provenance:` line before `Configuration Summary` using complete `phase.config`.
+    - Early wizard inventory renders the same shared summary line without config-aware `tilde-managed` selected labels because final selections are not known yet.
+    - Final wizard confirmation renders config-aware provenance before apply choices using the startup inventory report and completed wizard config.
+    - Unknown scanner/warning paths preserve `Warnings:` and individual warning lines and do not remove apply/continue choices.
+    - Summary blocks do not include unmatched Homebrew names, raw rc source lines, raw aliases, raw env values, or source targets.
+  </behavior>
+  <action>Extend the existing integration fixtures with direct installed, dependency, manual/app, scanner-owned OS, and unknown selected cases as needed. Add assertions for exactly one concise `Provenance:` line in config-first and wizard output. Use `ConfigFirstMode`, `Wizard`, or `ApplyStep` fixture rendering; do not invoke real scanner helpers or external commands. Keep negative assertions scoped to the inventory/provenance block so configured tool names in `ConfigSummary` do not create false failures.</action>
+  <verify>
+    <automated>npm run test:integration -- tests/integration/config-first.test.ts tests/integration/wizard-flow.test.tsx -t inventory</automated>
+  </verify>
+  <acceptance_criteria>
+    - New integration assertions fail before Task 2 because final wizard confirmation does not yet receive inventory provenance and rendered category wording is incomplete.
+    - Tests prove config-first and wizard rendering use shared summary lines rather than duplicate UI text.
+    - Unknown and warning paths are covered with fixture reports and no real external commands.
+  </acceptance_criteria>
+  <done>RED integration tests capture shared concise provenance rendering for PROV-02, PROV-03, and PROV-04.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Wire provenance summary through config-first and wizard confirmations</name>
+  <files>src/inventory/summary.ts, src/modes/config-first.tsx, src/modes/wizard.tsx, src/steps/apply.tsx, tests/integration/config-first.test.ts, tests/integration/wizard-flow.test.tsx</files>
+  <read_first>
+    - `src/inventory/summary.ts` — interrupted partial import of `formatProvenanceSummaryLine()`.
+    - `src/modes/config-first.tsx` — interrupted partial call `summarizeInventory(inventoryReport, phase.config)`.
+    - `src/modes/wizard.tsx` — has `inventoryReport` available at final step and currently passes only config to `ApplyStep`.
+    - `src/steps/apply.tsx` — final wizard confirmation where complete `TildeConfig` exists.
+    - `src/steps/inventory.tsx` — early wizard inventory should stay evidence-oriented with `summarizeInventory(report)`.
+    - `tests/integration/config-first.test.ts` and `tests/integration/wizard-flow.test.tsx` — RED tests from Task 1.
+    - `.planning/phases/04-provenance-summary/04-01-SUMMARY.md` — provenance helper outputs completed in Wave 1.
+  </read_first>
+  <behavior>
+    - `summarizeInventory(report, config?)` includes `formatProvenanceSummaryLine(report, config)` exactly once and keeps existing known-tool, Homebrew, dotfile, dotfile finding, and warning lines.
+    - `ConfigFirstMode` continues to render inventory before `ConfigSummary`, with `phase.config` passed into `summarizeInventory()` and apply/edit/start-over/cancel choices gated by inventory readiness.
+    - `ApplyStep` accepts optional `inventory?: InventoryReport`, renders `summarizeInventory(inventory, config)` before `ConfigSummary`, and keeps apply/finish/back behavior unchanged.
+    - `Wizard` passes its active startup `inventoryReport` to `ApplyStep` at the final step.
+    - `InventoryStep` remains command-free and uses `summarizeInventory(report)` without config because early wizard selections are not complete.
+  </behavior>
+  <action>Reconcile the interrupted edits in `summary.ts` and `config-first.tsx`, then add final wizard confirmation wiring by extending `ApplyStep` props with optional inventory and passing `inventoryReport` from `Wizard`. Do not change installer behavior, apply decision behavior, scanner ownership, or `ToolsStep` defaults. Do not add a verbose audit screen; default output remains one grouped provenance line plus existing aggregate lines and warning lines.</action>
+  <verify>
+    <automated>npm run test:integration -- tests/integration/config-first.test.ts tests/integration/wizard-flow.test.tsx -t inventory</automated>
+    <automated>npm run test -- tests/unit/inventory-provenance.test.ts tests/unit/inventory-scanner.test.ts</automated>
+    <automated>npm run build</automated>
+  </verify>
+  <acceptance_criteria>
+    - Config-first and wizard tests pass and show the same `Provenance:` line shape from `summarizeInventory()`.
+    - Final wizard confirmation has config-aware selected provenance; early wizard inventory remains evidence-oriented.
+    - Unknown selected tools and scanner warnings do not block apply/continue choices.
+    - No UI component implements its own provenance classifier or hardcoded category maps.
+    - Existing partial source edits are reconciled without resetting unrelated workspace changes.
+  </acceptance_criteria>
+  <done>Shared provenance output is visible in config-first and wizard confirmation paths, with targeted unit and integration tests passing.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|---|---|
+| shared summary helper -> Ink components | Derived provenance and warnings become terminal output. |
+| wizard state -> final apply confirmation | Completed config and startup inventory combine for selected-tool explanations. |
+| failed scanner report -> apply/config-first choices | Warning-backed reports must inform without blocking configured action. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|---|---|---|---|---|
+| T-04-04 | Information Disclosure | `summarizeInventory()` rendering | mitigate | Integration tests assert no raw rc/source/env details, unmatched Homebrew names, or verbose evidence dumps in normal output. |
+| T-04-05 | Tampering | config-first/wizard UI wording | mitigate | UI renders shared helper output only; no per-step classifier maps. |
+| T-04-06 | Denial of Service | unknown/failed scanner paths | mitigate | Tests assert warnings are preserved and apply/continue choices remain available after failed or unknown reports. |
+| T-04-SC | Tampering | npm/pip/cargo installs | accept | No package-manager install tasks exist in this plan; no package legitimacy checkpoint is required. |
+</threat_model>
+
+<verification>
+Run targeted integration, unit, and build checks after implementation:
+- `npm run test:integration -- tests/integration/config-first.test.ts tests/integration/wizard-flow.test.tsx -t inventory`
+- `npm run test -- tests/unit/inventory-provenance.test.ts tests/unit/inventory-scanner.test.ts`
+- `npm run build`
+
+Before phase verification, run:
+- `npm test && npm run test:integration && npm run build && npm run lint`
+</verification>
+
+<success_criteria>
+- PROV-02 is satisfied by one concise grouped provenance line in normal config-first and wizard summary output.
+- PROV-03 explanations are visible at config-aware confirmation points without pretending early wizard inventory knows final selections.
+- PROV-04 is preserved because UI renders `summarizeInventory()` output and provenance derivation stays in `src/inventory/provenance.ts`.
+- Warnings and unknown selected tools remain non-blocking.
+- No verbose audit UI is added.
+</success_criteria>
+
+<output>
+Create `.planning/phases/04-provenance-summary/04-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/04-provenance-summary/04-02-SUMMARY.md
+++ b/.planning/phases/04-provenance-summary/04-02-SUMMARY.md
@@ -58,6 +58,7 @@ completed: 2026-06-20
 ## Task Commits
 
 1. **Task 1 and Task 2: Rendering tests and shared wiring** - `8d2cce4` (feat)
+2. **Verification fixture stabilization** - `2000c4c` (test)
 
 **Plan metadata:** pending docs commit
 
@@ -78,7 +79,7 @@ completed: 2026-06-20
 
 ## Deviations from Plan
 
-The scanner unit test mock was updated because `summarizeInventory()` now calls the provenance helper, which uses `getToolMetadata()`. This is a test-support change caused by the shared derivation boundary, not a production scope change.
+The scanner unit test mock was updated because `summarizeInventory()` now calls the provenance helper, which uses `getToolMetadata()`. Full integration also exposed two older fixture assumptions: one hand-built inventory fixture lacked dotfile counts, and one async config-detection assertion needed a longer settle time. These are test-support changes caused by the shared summary boundary and full-suite timing, not production scope changes.
 
 **Total deviations:** 1 test-support adjustment.
 **Impact on plan:** Required to keep existing scanner summary coverage compatible with the shared helper.

--- a/.planning/phases/04-provenance-summary/04-02-SUMMARY.md
+++ b/.planning/phases/04-provenance-summary/04-02-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 04-provenance-summary
+plan: 2
+subsystem: inventory-ui
+tags: [provenance, ink, config-first, wizard, vitest]
+requires:
+  - phase: 04-provenance-summary
+    provides: Shared provenance derivation and grouped summary formatting from Plan 04-01
+provides:
+  - Config-first confirmation provenance summary with complete TildeConfig intent
+  - Final wizard apply confirmation provenance summary with startup inventory and completed config
+  - Integration coverage for concise shared provenance output and warning preservation
+affects: [config-first, wizard-confirmation, inventory-summary]
+tech-stack:
+  added: []
+  patterns:
+    - UI components render shared summarizeInventory output instead of duplicating provenance logic
+key-files:
+  created: []
+  modified:
+    - src/inventory/summary.ts
+    - src/modes/config-first.tsx
+    - src/modes/wizard.tsx
+    - src/steps/apply.tsx
+    - tests/integration/config-first.test.ts
+    - tests/integration/wizard-flow.test.tsx
+    - tests/unit/inventory-scanner.test.ts
+key-decisions:
+  - "Early wizard inventory remains evidence-only because final selections are not known yet."
+  - "Config-first and final wizard confirmation pass complete config intent into summarizeInventory()."
+  - "Normal output remains one Provenance line plus existing aggregate inventory and warning lines."
+patterns-established:
+  - "summarizeInventory(report, config?) is the only UI-facing summary entry point for provenance output."
+requirements-completed: [PROV-01, PROV-02, PROV-03, PROV-04]
+duration: 4 min
+completed: 2026-06-20
+---
+
+# Phase 04 Plan 02: Shared Provenance Rendering Summary
+
+**Config-aware provenance summaries rendered through config-first and final wizard confirmation paths**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-06-20T01:08:46Z
+- **Completed:** 2026-06-20T01:12:02Z
+- **Tasks:** 2
+- **Files modified:** 7
+
+## Accomplishments
+
+- Added `summarizeInventory(report, config?)` provenance output to config-first and final wizard confirmation paths.
+- Extended `ApplyStep` to accept optional inventory and render config-aware provenance before `ConfigSummary` and apply choices.
+- Preserved early wizard inventory as evidence-oriented output by continuing to call `summarizeInventory(report)` without config.
+- Added integration coverage for exactly one concise provenance line, config-aware selected tools, warning preservation, and no raw rc/source details.
+
+## Task Commits
+
+1. **Task 1 and Task 2: Rendering tests and shared wiring** - `8d2cce4` (feat)
+
+**Plan metadata:** pending docs commit
+
+## Files Created/Modified
+
+- `src/inventory/summary.ts` - Accepts optional config and includes `formatProvenanceSummaryLine()` exactly once.
+- `src/modes/config-first.tsx` - Passes complete config into inventory summary at confirmation.
+- `src/modes/wizard.tsx` - Passes startup inventory into final `ApplyStep`.
+- `src/steps/apply.tsx` - Renders config-aware inventory summary before the final config summary.
+- `tests/integration/config-first.test.ts` - Asserts config-aware provenance in config-first inventory block.
+- `tests/integration/wizard-flow.test.tsx` - Covers early evidence-only inventory and final config-aware apply confirmation.
+- `tests/unit/inventory-scanner.test.ts` - Updates mocked registry shape to include `getToolMetadata()`.
+
+## Decisions Made
+
+- Final wizard confirmation is the config-aware provenance surface; early inventory remains non-config-aware to avoid pretending final choices are known.
+- Existing warning rendering stays unchanged and follows the shared inventory summary lines.
+
+## Deviations from Plan
+
+The scanner unit test mock was updated because `summarizeInventory()` now calls the provenance helper, which uses `getToolMetadata()`. This is a test-support change caused by the shared derivation boundary, not a production scope change.
+
+**Total deviations:** 1 test-support adjustment.
+**Impact on plan:** Required to keep existing scanner summary coverage compatible with the shared helper.
+
+## Issues Encountered
+
+Initial config-first assertion expected only Homebrew as selected, but the fixture config also selects `ripgrep` and `fd`. The assertion was corrected to reflect config-aware provenance.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Verification
+
+- `npm run test:integration -- tests/integration/config-first.test.ts tests/integration/wizard-flow.test.tsx -t inventory` - passed
+- `npm run test -- tests/unit/inventory-provenance.test.ts tests/unit/inventory-scanner.test.ts` - passed
+- `npm run build` - passed
+
+## Next Phase Readiness
+
+All Phase 04 plans are complete and ready for phase-level verification.
+
+---
+*Phase: 04-provenance-summary*
+*Completed: 2026-06-20*

--- a/.planning/phases/04-provenance-summary/04-CONTEXT.md
+++ b/.planning/phases/04-provenance-summary/04-CONTEXT.md
@@ -1,0 +1,94 @@
+# Phase 04: Provenance Summary - Context
+
+**Gathered:** 2026-06-19
+**Status:** Ready for planning
+**Source:** User-provided Phase 04 Provenance Summary Context
+
+<domain>
+## Phase Boundary
+
+Phase 04 derives and renders provenance from existing metadata, config intent, and `InventoryReport` evidence. It does not change installer behavior, add destructive scans, or build a verbose audit UI.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Provenance Semantics
+
+- `tilde-managed` means selected by the current config or wizard run.
+- If a selected tool is already installed, the primary label is `tilde-managed`; detail preserves installed/direct/dependency/manual evidence.
+- Homebrew `dependency` remains explicit evidence and detail.
+- Manual, App Store, and manual GUI labels are metadata-driven.
+- OS-provided applies only to known scanner-owned core tools and shells.
+- `unknown` means insufficient or inconclusive scanner or metadata evidence.
+
+### Shared Derivation
+
+- Add a shared provenance helper, separate from UI components, deriving labels and action explanations from config intent, metadata, and inventory.
+- Provenance data must be derived from scanner output and metadata rather than duplicated per step.
+- Keep detailed provenance evidence structured for tests and future audit views, not as a new verbose UI in this phase.
+
+### Output Behavior
+
+- Keep normal output concise: one provenance summary line with grouped counts, up to 3 examples per group, and `+N more`.
+- Use shared summary output in both wizard inventory and config-first confirmation.
+- Explanations are action-oriented: install, skip because present, leave present/unmanaged, or proceed cautiously when unknown.
+- Selected dependency-installed tools read as selected and already present as a dependency; no install needed unless future logic promotes direct install.
+- Unknown selected tools do not block apply; preserve warnings and follow configured action.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+Downstream agents MUST read these before planning or implementing.
+
+### Planning
+
+- `.planning/PROJECT.md` - Project goal and constraints.
+- `.planning/REQUIREMENTS.md` - PROV-01 through PROV-04.
+- `.planning/ROADMAP.md` - Phase 04 goal, success criteria, and plan slots.
+- `.planning/STATE.md` - Prior decisions and current milestone state.
+- `.planning/phases/01-tool-metadata-registry/01-CONTEXT.md` - Metadata registry decisions.
+- `.planning/phases/02-machine-inventory-scanner/02-CONTEXT.md` - Inventory evidence and scanner decisions.
+- `.planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md` - Summary and dotfile mapping decisions.
+
+### Implementation
+
+- `src/inventory/report.ts` - `InventoryReport`, tool facts, evidence, and warnings.
+- `src/inventory/summary.ts` - Shared inventory summary output used by UI flows.
+- `src/steps/inventory.tsx` - Wizard inventory rendering path.
+- `src/modes/config-first.tsx` - Config-first confirmation rendering path.
+
+</canonical_refs>
+
+<specifics>
+## Test Plan
+
+- Unit-test derivation precedence for managed, already-installed, dependency, manual GUI, OS-provided, unmanaged, and unknown.
+- Integration-test wizard and config-first summaries share the same provenance lines.
+- Test unknown and warning paths with mocked Homebrew scanner failures.
+- Keep external commands mocked.
+
+## Current Workspace Note
+
+This context was created after an interrupted implementation attempt. The following source edits may already exist in the working tree and should be reviewed before execution continues:
+
+- `src/inventory/provenance.ts`
+- `src/inventory/summary.ts`
+- `src/modes/config-first.tsx`
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- A verbose audit view for detailed provenance evidence is deferred. This phase should preserve structured data for future audit views without adding one.
+
+</deferred>
+
+---
+
+*Phase: 04-provenance-summary*
+*Context gathered: 2026-06-19*

--- a/.planning/phases/04-provenance-summary/04-PATTERNS.md
+++ b/.planning/phases/04-provenance-summary/04-PATTERNS.md
@@ -1,0 +1,652 @@
+# Phase 04: Provenance Summary - Pattern Map
+
+**Mapped:** 2026-06-20
+**Files analyzed:** 5
+**Analogs found:** 5 / 5
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `src/inventory/provenance.ts` | utility | transform | `src/inventory/scan.ts` + current partial `src/inventory/provenance.ts` | exact |
+| `src/inventory/summary.ts` | utility | transform | `src/inventory/summary.ts` current summary formatter | exact |
+| `src/modes/config-first.tsx` | component | event-driven | `src/modes/config-first.tsx` current confirmation rendering | exact |
+| `tests/unit/inventory-provenance.test.ts` | test | transform | `tests/unit/inventory-scanner.test.ts` | role-match |
+| `tests/integration/config-first.test.ts` / `tests/integration/wizard-flow.test.tsx` | test | event-driven | existing config-first and wizard inventory tests | exact |
+
+## Pattern Assignments
+
+### `src/inventory/provenance.ts` (utility, transform)
+
+**Analog:** `src/inventory/scan.ts` and current partial `src/inventory/provenance.ts`
+
+**Imports pattern** (`src/inventory/provenance.ts` lines 1-3):
+
+```typescript
+import type { TildeConfig } from '../config/schema.js';
+import { getToolMetadata } from '../tools/registry.js';
+import type { InventoryEvidence, InventoryReport, InventoryToolCategory, InventoryToolFact } from './report.js';
+```
+
+Copy the relative import style with `.js` extensions. Keep provenance under `src/inventory/` and depend on `InventoryReport`, `TildeConfig`, and metadata registry helpers rather than UI components.
+
+**Report contract pattern** (`src/inventory/report.ts` lines 14-29, 64-70):
+
+```typescript
+export type InventoryEvidence =
+  | { type: 'homebrew-formula'; id: string; requestStatus: HomebrewRequestStatus }
+  | { type: 'homebrew-cask'; id: string; requestStatus: Extract<HomebrewRequestStatus, 'direct'> }
+  | { type: 'app-path'; path: string; exists: boolean }
+  | { type: 'command'; command: string; outcome: 'succeeded' | 'failed' | 'unknown'; version?: string }
+  | { type: 'shell'; name: string; source: 'process-env' | 'scanner' }
+  | { type: 'inconclusive'; source: InventoryWarningSource; reason: string; warningId?: string };
+
+export interface InventoryToolFact {
+  toolId: string;
+  label: string;
+  category: InventoryToolCategory;
+  installed: InventoryInstallState;
+  evidence: InventoryEvidence[];
+  warningIds: string[];
+}
+
+export interface InventoryReport {
+  tools: InventoryToolFact[];
+  unmatchedHomebrew: InventoryHomebrewAudit;
+  homebrew: InventoryHomebrewSummary;
+  dotfiles: DotfileMap;
+  warnings: InventoryWarning[];
+  environment: InventoryEnvironmentSnapshot;
+}
+```
+
+Provenance should classify these existing facts only. Do not add a new scanner or call external commands.
+
+**Metadata lookup pattern** (`src/tools/registry.ts` lines 18-32):
+
+```typescript
+export const allToolMetadata = validateToolMetadata([
+  ...browserToolMetadata,
+  ...noteTakingToolMetadata,
+  ...homebrewToolMetadata,
+  ...vfoxToolMetadata,
+  ...vscodeToolMetadata,
+  ...neovimToolMetadata,
+  ...jetbrainsToolMetadata,
+  ...cursorToolMetadata,
+  ...zedToolMetadata,
+]);
+
+export function getToolMetadata(id: string): ToolMetadata | undefined {
+  return allToolMetadata.find(tool => tool.id === id);
+}
+```
+
+Use `getToolMetadata()` for labels, categories, app paths, Homebrew ids, and manual notes. Do not duplicate registry maps inside UI steps.
+
+**Core transform pattern** (`src/inventory/provenance.ts` lines 54-91):
+
+```typescript
+export function deriveInventoryProvenance(
+  report: InventoryReport,
+  config?: TildeConfig
+): ToolProvenance[] {
+  const selectedToolIds = getSelectedToolIds(config);
+  const factsById = new Map(report.tools.map(tool => [tool.toolId, tool]));
+
+  for (const selectedToolId of selectedToolIds) {
+    if (!factsById.has(selectedToolId)) {
+      const metadata = getToolMetadata(selectedToolId);
+      factsById.set(selectedToolId, {
+        toolId: selectedToolId,
+        label: metadata?.label ?? selectedToolId,
+        category: metadata?.category ?? 'core-tool',
+        installed: 'unknown',
+        evidence: [{ type: 'inconclusive', source: 'scanner', reason: 'No inventory fact was collected for this selected tool.' }],
+        warningIds: [],
+      });
+    }
+  }
+
+  return [...factsById.values()].map(tool => {
+    const selected = selectedToolIds.has(tool.toolId);
+    const provenance = classifyToolProvenance(tool, selected);
+
+    return {
+      toolId: tool.toolId,
+      label: tool.label,
+      category: tool.category,
+      installed: tool.installed,
+      selected,
+      provenance,
+      detail: buildDetail(tool, provenance, selected),
+      action: buildAction(tool, provenance, selected),
+      evidence: tool.evidence,
+      warningIds: tool.warningIds,
+    };
+  });
+}
+```
+
+Keep this shape, but align the user-facing labels with Phase 04 semantics: selected tools first become `tilde-managed`; installed unselected tools should display as already installed/unmanaged as appropriate; Homebrew dependency remains explicit; OS-provided only applies to scanner-owned shell/core ids.
+
+**Scanner-owned OS evidence pattern** (`src/inventory/scan.ts` lines 341-377):
+
+```typescript
+function createShellFacts(activeShell?: string): InventoryToolFact[] {
+  return SHELL_IDS.map(shell => {
+    const isActive = activeShell?.split('/').pop() === shell;
+    return {
+      toolId: `shell:${shell}`,
+      label: shell,
+      category: 'shell',
+      installed: isActive ? 'installed' : 'unknown',
+      evidence: isActive
+        ? [{ type: 'shell', name: shell, source: 'process-env' }]
+        : [{ type: 'inconclusive', source: 'environment', reason: `Shell ${shell} was not the active process shell.` }],
+      warningIds: [],
+    };
+  });
+}
+
+function createCoreToolFacts(
+  languages: DetectedLanguage[],
+  versionManagers: DetectedVersionManager[]
+): InventoryToolFact[] {
+  return CORE_TOOL_IDS.map(toolId => {
+    const language = languages.find(detected => detected.name === toolId);
+    const versionManager = versionManagers.find(detected => detected.name === toolId);
+    const version = language?.version;
+    const installed = language || versionManager;
+
+    return {
+      toolId: `core-tool:${toolId}`,
+      label: toolId,
+      category: 'core-tool',
+      installed: installed ? 'installed' : 'unknown',
+      evidence: installed
+        ? [{ type: 'command', command: toolId, outcome: 'succeeded', version }]
+        : [{ type: 'inconclusive', source: 'environment', reason: `Core tool ${toolId} was not detected.` }],
+      warningIds: [],
+    };
+  });
+}
+```
+
+Classify `os-provided` only for these scanner-owned ids/categories with scanner evidence. Do not classify arbitrary selected metadata ids as OS-provided.
+
+**Error/warning pattern** (`src/inventory/scan.ts` lines 143-167, 391-398):
+
+```typescript
+async function scanHomebrewList(
+  name: 'formulae' | 'casks',
+  helper: () => Promise<string[]>,
+  warnings: InventoryWarning[]
+): Promise<string[] | null> {
+  try {
+    return await helper();
+  } catch {
+    warnings.push(createWarning('homebrew', `Homebrew ${name} could not be read; related inventory facts are unknown.`));
+    return null;
+  }
+}
+
+function createWarning(source: InventoryWarningSource, message: string, toolId?: string, id?: string): InventoryWarning {
+  return {
+    id: id ?? `${source}:${message}`,
+    source,
+    severity: 'warning',
+    message,
+    toolId,
+  };
+}
+```
+
+Provenance should preserve `warningIds` and use inconclusive evidence/action text. Unknown selected tools must not block apply.
+
+---
+
+### `src/inventory/summary.ts` (utility, transform)
+
+**Analog:** current `src/inventory/summary.ts`
+
+**Imports pattern** (`src/inventory/summary.ts` lines 1-3):
+
+```typescript
+import type { InventoryReport, InventoryToolFact } from './report.js';
+import type { TildeConfig } from '../config/schema.js';
+import { formatProvenanceSummaryLine } from './provenance.js';
+```
+
+Use type imports for report/config and a normal import for the provenance formatter.
+
+**Core summary pattern** (`src/inventory/summary.ts` lines 9-35):
+
+```typescript
+export function summarizeInventory(report: InventoryReport, config?: TildeConfig): string[] {
+  const installedKnownTools = getInstalledKnownToolFacts(report);
+  const installedKnownToolSummary = installedKnownTools.length > 0
+    ? installedKnownTools.map(tool => tool.label).join(', ')
+    : 'none';
+  const lines = [
+    `Known installed tools: ${installedKnownToolSummary}`,
+    formatProvenanceSummaryLine(report, config),
+    `Homebrew formulae: ${report.homebrew.directFormulaeCount} direct, ${report.homebrew.dependencyFormulaeCount} dependencies, ${report.homebrew.unknownFormulaeCount} unknown`,
+    `Homebrew casks: ${report.homebrew.installedCasksCount} installed, ${report.homebrew.unmatchedCasksCount} unmatched`,
+    `Dotfiles: ${report.dotfiles.counts.knownFiles} known, ${report.dotfiles.counts.unknownFiles} unknown, ${report.dotfiles.counts.warnings} warnings`,
+  ];
+
+  if (report.dotfiles.counts.knownFindingsCount > 0 || report.dotfiles.counts.unknownFindingsCount > 0) {
+    lines.push(
+      `Dotfile findings: ${report.dotfiles.counts.knownFindingsCount} known hooks, ${report.dotfiles.counts.unknownFindingsCount} unknown rc findings`
+    );
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push('Warnings:');
+    for (const warning of report.warnings) {
+      lines.push(`Warning: ${warning.message}`);
+    }
+  }
+
+  return lines;
+}
+```
+
+Keep one concise provenance line inside `summarizeInventory(report, config?)`. UI should continue rendering returned strings and should not duplicate provenance grouping.
+
+**Group formatting pattern** (`src/inventory/provenance.ts` lines 94-118):
+
+```typescript
+export function summarizeProvenanceGroups(
+  provenance: ToolProvenance[],
+  maxExamples = 3
+): ProvenanceGroupSummary[] {
+  return PROVENANCE_ORDER.map(label => {
+    const tools = provenance.filter(tool => tool.provenance === label);
+    return {
+      provenance: label,
+      count: tools.length,
+      examples: tools.slice(0, maxExamples).map(tool => tool.label),
+      remaining: Math.max(0, tools.length - maxExamples),
+    };
+  }).filter(group => group.count > 0);
+}
+
+export function formatProvenanceSummaryLine(report: InventoryReport, config?: TildeConfig): string {
+  const groups = summarizeProvenanceGroups(deriveInventoryProvenance(report, config));
+  const formattedGroups = groups.map(group => {
+    const examples = group.examples.join(', ');
+    const more = group.remaining > 0 ? `, +${group.remaining} more` : '';
+    return `${PROVENANCE_LABELS[group.provenance]} ${group.count}${examples ? ` (${examples}${more})` : ''}`;
+  });
+
+  return `Provenance: ${formattedGroups.length > 0 ? formattedGroups.join('; ') : 'none'}`;
+}
+```
+
+Retain the `maxExamples = 3` behavior and `+N more` grouping required by Phase 04.
+
+---
+
+### `src/modes/config-first.tsx` (component, event-driven)
+
+**Analog:** current `src/modes/config-first.tsx`
+
+**Imports pattern** (`src/modes/config-first.tsx` lines 1-20):
+
+```typescript
+import React, { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
+import SelectInput from 'ink-select-input';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { fromZodError } from 'zod-validation-error';
+import { TildeConfigSchema, type TildeConfig } from '../config/schema.js';
+import { runMigrations, CURRENT_SCHEMA_VERSION } from '../config/migrations/runner.js';
+import { atomicWriteConfig } from '../config/writer.js';
+import { installAll } from '../installer/index.js';
+import { writeAll } from '../dotfiles/writer.js';
+import { pluginRegistry } from '../plugins/registry.js';
+import { ConfigSummary } from '../ui/config-summary.js';
+import { ContextsStep } from '../steps/contexts.js';
+import { ShellStep } from '../steps/shell.js';
+import type { InventoryReport, InventoryScanState } from '../inventory/report.js';
+import { summarizeInventory } from '../inventory/summary.js';
+```
+
+Preserve the existing Ink/React import style and `.js` extensions.
+
+**Confirm rendering pattern** (`src/modes/config-first.tsx` lines 163-199):
+
+```typescript
+if (phase.type === 'confirm') {
+  if (inventoryState?.status === 'loading') {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Scanning inventory...</Text>
+        <Text dimColor>Apply choices will be available after the scan finishes.</Text>
+      </Box>
+    );
+  }
+
+  const inventoryReport = inventoryState?.report ?? inventory;
+  const inventoryHeading = inventoryState?.status === 'failed'
+    ? 'Inventory scan failed'
+    : 'Inventory scan complete';
+  const items = [
+    { label: 'Apply this configuration', value: 'apply' },
+    ...(onEdit ? [{ label: 'Edit configuration', value: 'edit' }] : []),
+    ...(onStartOver ? [{ label: 'Start over (run wizard)', value: 'start-over' }] : []),
+    { label: 'Cancel', value: 'cancel' },
+  ];
+  return (
+    <Box flexDirection="column">
+      {inventoryReport && (
+        <Box flexDirection="column">
+          <Text bold>{inventoryHeading}</Text>
+          <Box marginTop={1} flexDirection="column">
+            {summarizeInventory(inventoryReport, phase.config).map(line => (
+              <Text
+                key={line}
+                color={line.startsWith('Warning') ? 'yellow' : 'green'}
+              >
+                {line}
+              </Text>
+            ))}
+          </Box>
+        </Box>
+      )}
+```
+
+Config-first has complete `TildeConfig`; pass `phase.config` into `summarizeInventory()` here so selected tools can be labeled `tilde-managed`.
+
+**Wizard inventory rendering pattern** (`src/steps/inventory.tsx` lines 39-66):
+
+```typescript
+return (
+  <Box flexDirection="column">
+    <Text bold>{heading}</Text>
+    <Box marginTop={1} flexDirection="column">
+      {summarizeInventory(report).map(line => (
+        <Text
+          key={line}
+          color={line.startsWith('Warning') ? 'yellow' : 'green'}
+        >
+          {line}
+        </Text>
+      ))}
+    </Box>
+    <Box marginTop={1}>
+      <SelectInput
+        items={confirmItems}
+        onSelect={(item) => {
+          if (item.value === 'back' && onBack) {
+            onBack();
+            return;
+          }
+
+          onComplete({ inventory: report });
+        }}
+      />
+    </Box>
+  </Box>
+);
+```
+
+Early wizard inventory does not have final config intent. Keep it evidence-oriented unless a later wizard confirmation path has complete `TildeConfig`.
+
+---
+
+### `tests/unit/inventory-provenance.test.ts` (test, transform)
+
+**Analog:** `tests/unit/inventory-scanner.test.ts`
+
+**Imports and mock pattern** (`tests/unit/inventory-scanner.test.ts` lines 1-27, 34-108):
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const {
+  mockListInstalledFormulae,
+  mockListInstalledCasks,
+  mockListInstalledOnRequestFormulae,
+  mockDetectLanguages,
+  mockDetectVersionManagers,
+  mockAccess,
+} = vi.hoisted(() => ({
+  mockListInstalledFormulae: vi.fn(),
+  mockListInstalledCasks: vi.fn(),
+  mockListInstalledOnRequestFormulae: vi.fn(),
+  mockDetectLanguages: vi.fn(),
+  mockDetectVersionManagers: vi.fn(),
+  mockAccess: vi.fn(),
+}));
+
+vi.mock('../../src/utils/package-manager.js', () => ({
+  listInstalledFormulae: mockListInstalledFormulae,
+  listInstalledCasks: mockListInstalledCasks,
+  listInstalledOnRequestFormulae: mockListInstalledOnRequestFormulae,
+}));
+```
+
+For provenance unit tests, prefer direct `InventoryReport` fixtures and mock `../../src/tools/registry.js` only if metadata-specific branches need isolation.
+
+**Evidence assertion pattern** (`tests/unit/inventory-scanner.test.ts` lines 174-188, 220-247):
+
+```typescript
+const formulaFact = report.tools.find(tool => tool.toolId === 'test-cli');
+expect(formulaFact).toEqual(expect.objectContaining({
+  installed: 'installed',
+  evidence: expect.arrayContaining([
+    expect.objectContaining({ type: 'homebrew-formula', id: 'test-cli' }),
+  ]),
+}));
+
+const installedEditor = report.tools.find(tool => tool.toolId === 'test-editor-installed');
+expect(installedEditor).toEqual(expect.objectContaining({
+  installed: 'installed',
+  evidence: expect.arrayContaining([
+    expect.objectContaining({
+      type: 'app-path',
+      path: '/Applications/Installed Test Editor.app',
+      exists: true,
+    }),
+  ]),
+}));
+```
+
+Copy this assertion style for derivation precedence: selected installed direct, selected dependency, selected missing, manual/app-path, scanner-owned OS, unselected unmanaged, and unknown.
+
+**Unknown/warning pattern** (`tests/unit/inventory-scanner.test.ts` lines 281-335):
+
+```typescript
+it('keeps the report usable with warnings and unknown facts when Homebrew helpers fail', async () => {
+  mockListInstalledFormulae.mockRejectedValueOnce(new Error('brew not found'));
+
+  const { scanInventory } = await import('../../src/inventory/scan.js');
+
+  const report = await scanInventory(tmpHome);
+
+  expect(report.warnings).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      source: 'homebrew',
+      severity: 'warning',
+    }),
+  ]));
+
+  const formulaFact = report.tools.find(tool => tool.toolId === 'test-cli');
+  expect(formulaFact).toEqual(expect.objectContaining({
+    installed: 'unknown',
+    evidence: expect.arrayContaining([
+      expect.objectContaining({ type: 'inconclusive', source: 'homebrew' }),
+    ]),
+  }));
+
+  expect(report.unmatchedHomebrew.formulae).toEqual([]);
+});
+```
+
+Add provenance tests for unknown selected tools and scanner failure warnings. Assert cautious action text but no blocking/error behavior.
+
+---
+
+### `tests/integration/config-first.test.ts` and `tests/integration/wizard-flow.test.tsx` (test, event-driven)
+
+**Analog:** existing config-first and wizard flow integration tests
+
+**Config-first fixture pattern** (`tests/integration/config-first.test.ts` lines 27-125):
+
+```typescript
+describe('ConfigFirstMode integration', () => {
+  function createInventoryFixture(): InventoryReport {
+    const dotfiles = {
+      ...createEmptyInventoryReport().dotfiles,
+      files: [
+        {
+          path: '/Users/test/.zshrc',
+          scope: 'home' as const,
+          state: 'mixed' as const,
+          toolIds: ['direnv'],
+          warningIds: [],
+          findings: [
+            {
+              kind: 'tool-init-hook' as const,
+              classification: 'known' as const,
+              toolIds: ['direnv'],
+              reason: 'rc-file-content',
+              confidence: 'high' as const,
+              safeDetails: { toolId: 'direnv', sourceLine: 'eval "$(direnv hook zsh)"' },
+            },
+```
+
+Use fixture reports rather than real scans. Extend this fixture with selected direct/dependency/manual/unknown tool facts for provenance line assertions.
+
+**Config-first summary assertion pattern** (`tests/integration/config-first.test.ts` lines 163-193):
+
+```typescript
+it('renders inventory summary before configuration summary', async () => {
+  const { ConfigFirstMode } = await import('../../src/modes/config-first.js');
+  const onComplete = vi.fn();
+  const inventoryState: InventoryScanState = {
+    status: 'ready',
+    report: createInventoryFixture(),
+  };
+  const { lastFrame } = render(
+    React.createElement(ConfigFirstMode, { configPath: fixturePath, onComplete, inventoryState })
+  );
+
+  await new Promise((r) => setTimeout(r, 300));
+
+  const frame = lastFrame() ?? '';
+  const inventoryIndex = frame.indexOf('Inventory scan complete');
+  const configIndex = frame.indexOf('Configuration Summary');
+  expect(inventoryIndex).toBeGreaterThanOrEqual(0);
+  expect(configIndex).toBeGreaterThanOrEqual(0);
+  expect(inventoryIndex).toBeLessThan(configIndex);
+  const inventoryBlock = frame.slice(inventoryIndex, configIndex);
+  expect(inventoryBlock).toContain('Known installed tools: Homebrew');
+  expect(inventoryBlock).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
+  expect(inventoryBlock).toContain('Dotfiles:');
+  expect(inventoryBlock).toContain('Dotfile findings: 1 known hooks, 2 unknown rc findings');
+  expect(inventoryBlock).toContain('Warnings:');
+  expect(inventoryBlock).toContain('Warning: Homebrew direct/dependency status is unavailable.');
+  expect(inventoryBlock).not.toContain('ripgrep');
+  expect(inventoryBlock).not.toContain('alias gs=');
+  expect(inventoryBlock).not.toContain('eval "$(direnv hook zsh)"');
+  expect(inventoryBlock).not.toContain('~/.private-aliases');
+});
+```
+
+Add assertions for one shared `Provenance:` line before `Configuration Summary`. Keep negative assertions that raw rc details and unmatched Homebrew names do not leak.
+
+**Wizard summary assertion pattern** (`tests/integration/wizard-flow.test.tsx` lines 362-413):
+
+```typescript
+it('inventory wizard step uses inventory label and summarizes known installed tools', async () => {
+  const { Wizard } = await import('../../src/modes/wizard.js');
+
+  const { lastFrame } = render(
+    React.createElement(Wizard, {
+      initialStep: 1,
+      inventory: createInventoryFixture(),
+    } as React.ComponentProps<typeof Wizard> & { inventory: InventoryReport })
+  );
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+  const frame = lastFrame() ?? '';
+  expect(frame).toContain('Inventory');
+  expect(frame).not.toContain('Environment Capture');
+  expect(frame).toContain('Inventory scan complete');
+  expect(frame).toContain('Known installed tools:');
+  expect(frame).toContain('Dotfiles:');
+});
+
+it('inventory wizard step summarizes Homebrew counts and warnings without unmatched names', async () => {
+  const { Wizard } = await import('../../src/modes/wizard.js');
+  const inventory = createInventoryFixture({
+    warnings: [
+      {
+        id: 'homebrew-request-state-unavailable',
+        source: 'homebrew',
+        severity: 'warning',
+        message: 'Homebrew direct/dependency status is unavailable.',
+      },
+    ],
+  });
+```
+
+Use the same provenance formatter in wizard inventory, but remember early wizard has no final config. Assert evidence-based groups there, and put `tilde-managed` selected assertions in config-first or final wizard confirmation where a config is available.
+
+## Shared Patterns
+
+### ESM Imports
+
+**Source:** `src/inventory/provenance.ts`, `src/modes/config-first.tsx`  
+**Apply to:** all new/modified TypeScript files
+
+Use relative imports with `.js` extensions and `import type` for type-only imports.
+
+### Evidence-First Classification
+
+**Source:** `src/inventory/report.ts`, `src/inventory/scan.ts`  
+**Apply to:** `src/inventory/provenance.ts`, unit tests
+
+Classify from `InventoryToolFact.evidence`, `InventoryToolFact.installed`, metadata install fields, and optional `TildeConfig`. Do not inspect the machine or call `brew`, `gh`, `op`, `vfox`, or `defaultbrowser` from provenance code.
+
+### Selected Config Precedence
+
+**Source:** Phase 04 context and current `src/inventory/provenance.ts` selected branch  
+**Apply to:** `deriveInventoryProvenance()`
+
+Selected ids from `packageManagers`, `versionManagers[].name`, `tools`, browser selections/default, editors, and `aiTools[].name` take primary `tilde-managed` precedence. Preserve direct/dependency/manual/app evidence in `detail` and `action`.
+
+### Concise Terminal Output
+
+**Source:** `src/inventory/summary.ts`, `src/steps/inventory.tsx`, `src/modes/config-first.tsx`  
+**Apply to:** UI rendering paths and integration tests
+
+All normal rendering should go through `summarizeInventory(report, config?)` and produce one grouped `Provenance:` line with counts, up to 3 examples per group, and `+N more`.
+
+### Test Isolation
+
+**Source:** `tests/unit/inventory-scanner.test.ts`, `tests/integration/config-first.test.ts`, `tests/integration/wizard-flow.test.tsx`  
+**Apply to:** new provenance tests
+
+Use Vitest, direct fixtures, `vi.mock`, and `ink-testing-library`. External command behavior stays mocked or bypassed through fixture reports.
+
+## No Analog Found
+
+All identified files have close analogs in the existing codebase.
+
+## Metadata
+
+**Analog search scope:** `src/inventory/`, `src/modes/`, `src/steps/`, `src/tools/`, `tests/unit/`, `tests/integration/`  
+**Files scanned:** 14 targeted files from phase context and research  
+**Pattern extraction date:** 2026-06-20

--- a/.planning/phases/04-provenance-summary/04-RESEARCH.md
+++ b/.planning/phases/04-provenance-summary/04-RESEARCH.md
@@ -346,17 +346,19 @@ All claims in this research were verified against local project files, Phase con
 |---|-------|---------|---------------|
 | N/A | N/A | N/A | N/A |
 
-## Open Questions
+## Open Questions (RESOLVED)
 
 1. **Where should config-aware wizard provenance render?**
    - What we know: early `InventoryStep` runs before wizard selections, while `ApplyStep` receives completed `TildeConfig`. [VERIFIED: src/modes/wizard.tsx] [VERIFIED: src/steps/apply.tsx]
    - What's unclear: Phase 04 context says shared summary output in wizard inventory and config-first confirmation, but PROV-03 needs selected/skipped explanations that early inventory cannot know. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: .planning/REQUIREMENTS.md]
    - Recommendation: Plan evidence-only provenance in early wizard inventory and config-aware selected provenance in final wizard confirmation plus config-first confirmation. [VERIFIED: src/modes/wizard.tsx] [VERIFIED: src/modes/config-first.tsx]
+   - RESOLVED: Plan 04-02 renders evidence-oriented provenance in early `InventoryStep`, config-aware provenance in config-first confirmation via `summarizeInventory(inventoryReport, phase.config)`, and config-aware wizard provenance in final `ApplyStep` by passing the startup inventory report from `Wizard`. [VERIFIED: .planning/phases/04-provenance-summary/04-02-PLAN.md]
 
 2. **Should the internal `ProvenanceLabel` union include `homebrew-direct`?**
    - What we know: current partial code includes `homebrew-direct`, but PROV-01 names "already installed" and separately names Homebrew dependency. [VERIFIED: src/inventory/provenance.ts] [VERIFIED: .planning/REQUIREMENTS.md]
    - What's unclear: The internal type can keep evidence-specific labels, but the user-facing output must match phase semantics. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
    - Recommendation: Prefer user-facing provenance labels for `provenance` and store direct/dependency/manual evidence in `detail` or a structured evidence summary. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+   - RESOLVED: Plan 04-01 requires user-facing `ProvenanceLabel` values and explicitly removes `homebrew-direct` as a primary provenance label; direct Homebrew evidence remains structured evidence/detail, while unselected direct installs render as `already-installed` and dependencies render as `homebrew-dependency`. [VERIFIED: .planning/phases/04-provenance-summary/04-01-PLAN.md]
 
 ## Environment Availability
 

--- a/.planning/phases/04-provenance-summary/04-RESEARCH.md
+++ b/.planning/phases/04-provenance-summary/04-RESEARCH.md
@@ -1,0 +1,464 @@
+# Phase 04: Provenance Summary - Research
+
+**Researched:** 2026-06-20
+**Domain:** TypeScript CLI inventory provenance derivation and Ink summary rendering
+**Confidence:** HIGH for codebase architecture and phase scope; MEDIUM for external framework documentation
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+## Implementation Decisions
+
+### Provenance Semantics
+
+- `tilde-managed` means selected by the current config or wizard run.
+- If a selected tool is already installed, the primary label is `tilde-managed`; detail preserves installed/direct/dependency/manual evidence.
+- Homebrew `dependency` remains explicit evidence and detail.
+- Manual, App Store, and manual GUI labels are metadata-driven.
+- OS-provided applies only to known scanner-owned core tools and shells.
+- `unknown` means insufficient or inconclusive scanner or metadata evidence.
+
+### Shared Derivation
+
+- Add a shared provenance helper, separate from UI components, deriving labels and action explanations from config intent, metadata, and inventory.
+- Provenance data must be derived from scanner output and metadata rather than duplicated per step.
+- Keep detailed provenance evidence structured for tests and future audit views, not as a new verbose UI in this phase.
+
+### Output Behavior
+
+- Keep normal output concise: one provenance summary line with grouped counts, up to 3 examples per group, and `+N more`.
+- Use shared summary output in both wizard inventory and config-first confirmation.
+- Explanations are action-oriented: install, skip because present, leave present/unmanaged, or proceed cautiously when unknown.
+- Selected dependency-installed tools read as selected and already present as a dependency; no install needed unless future logic promotes direct install.
+- Unknown selected tools do not block apply; preserve warnings and follow configured action.
+
+### the agent's Discretion
+No explicit `## the agent's Discretion` section was provided in Phase 04 CONTEXT.md. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+### Deferred Ideas (OUT OF SCOPE)
+## Deferred Ideas
+
+- A verbose audit view for detailed provenance evidence is deferred. This phase should preserve structured data for future audit views without adding one.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| PROV-01 | tilde can label tools as tilde-managed, already installed, Homebrew dependency, manually installed, app-store/manual GUI install, OS-provided, or unknown. [VERIFIED: .planning/REQUIREMENTS.md] | Use a shared derivation helper over `InventoryReport.tools`, config intent, and `ToolMetadata.install` evidence; display category names should align with requirement language, while detail can preserve Homebrew direct/dependency/manual evidence. [VERIFIED: src/inventory/report.ts] [VERIFIED: src/tools/metadata.ts] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| PROV-02 | Wizard and/or config summary output shows provenance without overwhelming the user. [VERIFIED: .planning/REQUIREMENTS.md] | Keep one grouped `Provenance:` line through `summarizeInventory()` with 3 examples per group and `+N more`; existing wizard and config-first paths already render `summarizeInventory()`. [VERIFIED: src/inventory/summary.ts] [VERIFIED: src/steps/inventory.tsx] [VERIFIED: src/modes/config-first.tsx] |
+| PROV-03 | Provenance can explain why tilde selected or skipped a tool. [VERIFIED: .planning/REQUIREMENTS.md] | Derive action text from selected config intent plus installed state and evidence; config-first confirmation has a complete `TildeConfig`, while the early wizard inventory step does not yet have all wizard selections. [VERIFIED: src/config/schema.ts] [VERIFIED: src/modes/config-first.tsx] [VERIFIED: src/modes/wizard.tsx] |
+| PROV-04 | Provenance data is derived from scanner output and metadata rather than hardcoded per-step text. [VERIFIED: .planning/REQUIREMENTS.md] | Put derivation under `src/inventory/`, consume `getToolMetadata()` and inventory evidence, and keep Ink components as renderers only. [VERIFIED: src/inventory/report.ts] [VERIFIED: src/tools/registry.ts] [VERIFIED: src/steps/inventory.tsx] |
+</phase_requirements>
+
+## Summary
+
+Phase 04 should be planned as a pure derivation and presentation phase: no new scanners, no installer behavior changes, no destructive machine inspection, and no verbose audit UI. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] The existing code already has the right substrate: `InventoryReport` carries installed/missing/unknown state, evidence arrays, Homebrew request status, app-path evidence, warnings, and dotfile maps; `ToolMetadata` carries install identifiers, app paths, manual notes, and categories. [VERIFIED: src/inventory/report.ts] [VERIFIED: src/inventory/scan.ts] [VERIFIED: src/tools/metadata.ts]
+
+There are interrupted workspace edits that already add `src/inventory/provenance.ts`, import `formatProvenanceSummaryLine()` from `src/inventory/summary.ts`, and pass config into `summarizeInventory()` from config-first confirmation. [VERIFIED: src/inventory/provenance.ts] [VERIFIED: src/inventory/summary.ts] [VERIFIED: src/modes/config-first.tsx] Planning should account for that work but should not assume it is complete: the current helper uses implementation-shaped labels such as `homebrew-direct`, while PROV-01 and the Phase 04 context require user-facing provenance categories such as already installed, Homebrew dependency, manual/App Store/manual GUI, OS-provided, and unknown. [VERIFIED: src/inventory/provenance.ts] [VERIFIED: .planning/REQUIREMENTS.md] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**Primary recommendation:** finish a shared `src/inventory/provenance.ts` derivation helper, align display categories to PROV-01 semantics, route concise output through `summarizeInventory(report, config?)`, and add focused unit plus integration tests before touching UI behavior. [VERIFIED: src/inventory/summary.ts] [VERIFIED: tests/integration/config-first.test.ts] [VERIFIED: tests/integration/wizard-flow.test.tsx]
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|--------------|----------------|-----------|
+| Provenance derivation | CLI application source / inventory domain | Metadata registry | Derivation belongs in `src/inventory/` because it consumes `InventoryReport`; metadata lookup supplies install/category hints. [VERIFIED: src/inventory/report.ts] [VERIFIED: src/tools/registry.ts] |
+| Config intent detection | CLI application source / config domain | Wizard state | `TildeConfig` fields define selected package managers, version managers, tools, browsers, editors, and AI tools. [VERIFIED: src/config/schema.ts] |
+| Concise terminal rendering | Ink UI | Inventory summary helper | Wizard inventory and config-first render summary lines from `summarizeInventory()`, so wording belongs in the helper rather than components. [VERIFIED: src/inventory/summary.ts] [VERIFIED: src/steps/inventory.tsx] [VERIFIED: src/modes/config-first.tsx] |
+| Action explanations | CLI application source / inventory domain | Installer pipeline | This phase should explain install/skip/leave/proceed cautiously but not alter `installAll()` or `writeAll()`. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: src/installer/index.ts] |
+| Detailed audit evidence | Structured report data | Future audit UI | Phase 04 should preserve structured evidence for future audit views without adding a verbose UI. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+
+## Project Constraints (from AGENTS.md)
+
+- Runtime is Node.js >=20 with TypeScript NodeNext and `.js` import extensions; new modules must preserve ESM import style. [VERIFIED: AGENTS.md] [VERIFIED: tsconfig.json] [CITED: Context7 /microsoft/typescript]
+- UI is Ink/React terminal UI; provenance output must fit terminal workflows and support non-interactive paths where relevant. [VERIFIED: AGENTS.md] [CITED: Context7 /vadimdemedes/ink]
+- Platform is macOS-first; Homebrew, app bundles, shell rc files, and dotfiles discovery target macOS before cross-platform expansion. [VERIFIED: AGENTS.md] [VERIFIED: src/index.tsx]
+- Discovery must be non-destructive by default; Phase 04 should derive and render from existing report data rather than writing or deleting. [VERIFIED: AGENTS.md] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+- Do not resolve or persist raw secrets; environment variables and secret references remain backend references. [VERIFIED: AGENTS.md] [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md]
+- External commands such as `brew`, `gh`, `op`, `vfox`, and `defaultbrowser` must be mocked in automated tests. [VERIFIED: AGENTS.md] [VERIFIED: tests/unit/inventory-scanner.test.ts]
+- Before file-changing implementation work, use a GSD workflow entry point; this research artifact is the current GSD phase output. [VERIFIED: AGENTS.md]
+
+## Standard Stack
+
+### Core
+
+| Library | Project Version | Registry Check | Purpose | Why Standard |
+|---------|-----------------|----------------|---------|--------------|
+| TypeScript | `5.4` [VERIFIED: package.json] | latest `6.0.3`, modified 2026-06-18 [VERIFIED: npm registry] | Compile strict NodeNext source. [VERIFIED: tsconfig.json] | Existing repo compiler and NodeNext import rules; do not upgrade during this phase. [VERIFIED: package.json] [CITED: Context7 /microsoft/typescript] |
+| Ink | `^6.8.0` [VERIFIED: package.json] | latest `7.1.0`, modified 2026-06-17 [VERIFIED: npm registry] | Render terminal UI with `Box` and `Text`. [VERIFIED: src/steps/inventory.tsx] | Existing wizard/config-first UI framework; docs support `Box` layout plus `Text` content. [CITED: Context7 /vadimdemedes/ink] |
+| React | `^19.2.4` [VERIFIED: package.json] | not separately needed for this phase [VERIFIED: package.json] | Component model for Ink surfaces. [VERIFIED: src/steps/inventory.tsx] | Already paired with Ink throughout the repo. [VERIFIED: AGENTS.md] |
+| Vitest | `^4.1.2` [VERIFIED: package.json] | latest `4.1.9`, modified 2026-06-15 [VERIFIED: npm registry] | Unit and integration tests. [VERIFIED: vitest.config.ts] | Existing test runner supports `vi.mock` module mocking used in scanner/UI tests. [VERIFIED: tests/unit/inventory-scanner.test.ts] [CITED: Context7 /vitest-dev/vitest/v4.1.6] |
+
+### Supporting
+
+| Library | Project Version | Purpose | When to Use |
+|---------|-----------------|---------|-------------|
+| ink-testing-library | `^4.0.0` [VERIFIED: package.json] | Render Ink components in integration tests. [VERIFIED: tests/integration/config-first.test.ts] | Use for wizard/config-first summary assertions. [VERIFIED: tests/integration/wizard-flow.test.tsx] |
+| Zod | `^4.3.6` [VERIFIED: package.json] | Validate `TildeConfig`. [VERIFIED: src/config/schema.ts] | Rely on existing config validation; do not add separate provenance input validation framework. [VERIFIED: src/config/schema.ts] |
+
+### Alternatives Considered
+
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Existing `summarizeInventory()` | Separate provenance component text | Avoid: two UI paths already consume the shared summary helper, and Phase 04 requires shared output. [VERIFIED: src/inventory/summary.ts] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| Existing Vitest tests | New test framework | Avoid: Vitest is already configured and used for scanner and Ink integration tests. [VERIFIED: vitest.config.ts] [VERIFIED: tests/integration/wizard-flow.test.tsx] |
+| Existing metadata registry | Inline per-step provenance maps | Avoid: PROV-04 explicitly requires scanner/metadata-derived provenance. [VERIFIED: .planning/REQUIREMENTS.md] [VERIFIED: src/tools/registry.ts] |
+
+**Installation:**
+
+```bash
+# No new packages for Phase 04. [VERIFIED: package.json] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+```
+
+## Package Legitimacy Audit
+
+No external packages should be installed in this phase. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] The package legitimacy gate is not applicable because the standard stack is already present in `package.json` and `package-lock.json`. [VERIFIED: package.json] [VERIFIED: package-lock.json]
+
+| Package | Registry | Age | Downloads | Source Repo | Verdict | Disposition |
+|---------|----------|-----|-----------|-------------|---------|-------------|
+| N/A | npm | N/A | N/A | N/A | N/A | No install planned. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+
+**Packages removed due to [SLOP] verdict:** none. [VERIFIED: no new packages planned]
+**Packages flagged as suspicious [SUS]:** none. [VERIFIED: no new packages planned]
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```text
+Inventory startup scan
+  -> InventoryReport.tools[] evidence
+  -> InventoryReport.unmatchedHomebrew / warnings / dotfiles
+
+TildeConfig intent
+  -> selected ids from packageManagers, versionManagers, tools, browser, editors, aiTools
+
+Tool metadata registry
+  -> install.homebrew, install.appPath, install.manualNote, category, label
+
+InventoryReport + TildeConfig? + ToolMetadata
+  -> deriveInventoryProvenance()
+  -> ToolProvenance[] with label, selected, provenance, detail, action, evidence, warnings
+  -> summarizeProvenanceGroups(maxExamples=3)
+  -> formatProvenanceSummaryLine()
+  -> summarizeInventory(report, config?)
+  -> Ink Text lines in InventoryStep, ConfigFirstMode, and final wizard confirmation where config exists
+```
+
+This data flow follows the established boundary where app startup owns scanning and UI components render supplied report data. [VERIFIED: .planning/STATE.md] [VERIFIED: src/modes/wizard.tsx] [VERIFIED: src/steps/inventory.tsx]
+
+### Recommended Project Structure
+
+```text
+src/
+  inventory/
+    provenance.ts      # shared derivation, grouping, action/detail text [VERIFIED: current partial file exists]
+    summary.ts         # concise shared summary line integration [VERIFIED: src/inventory/summary.ts]
+    report.ts          # evidence/report contracts consumed by provenance [VERIFIED: src/inventory/report.ts]
+tests/
+  unit/
+    inventory-provenance.test.ts  # derivation precedence and grouping [VERIFIED: tests/unit layout]
+  integration/
+    wizard-flow.test.tsx          # wizard summary shared output [VERIFIED: tests/integration/wizard-flow.test.tsx]
+    config-first.test.ts          # config-first summary shared output [VERIFIED: tests/integration/config-first.test.ts]
+```
+
+### Pattern 1: Evidence-First Provenance Helper
+
+**What:** Convert `InventoryToolFact` plus config-selected ids and metadata into `ToolProvenance` records that preserve evidence and expose concise display/category/action fields. [VERIFIED: src/inventory/report.ts] [VERIFIED: src/inventory/provenance.ts]
+
+**When to use:** Use for every provenance label, including synthetic selected ids missing from scanner output. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**Example:**
+
+```typescript
+// Source: src/inventory/provenance.ts and Phase 04 CONTEXT.md
+const selected = selectedToolIds.has(tool.toolId);
+const label = selected
+  ? 'tilde-managed'
+  : classifyFromEvidenceAndMetadata(tool, getToolMetadata(tool.toolId));
+```
+
+### Pattern 2: Display Category vs Evidence Detail
+
+**What:** The primary display category should use user-facing PROV-01 labels, while detail text preserves lower-level facts such as direct Homebrew formula, dependency formula, cask, app path, manual note, and warnings. [VERIFIED: .planning/REQUIREMENTS.md] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: src/inventory/report.ts]
+
+**When to use:** Use when a selected tool is already installed or installed as a dependency; primary label remains `tilde-managed`, but detail/action explains why install can be skipped. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**Example:**
+
+```typescript
+// Source: Phase 04 CONTEXT.md
+if (selected) {
+  return {
+    provenance: 'tilde-managed',
+    detail: evidenceSummary(tool.evidence),
+    action: tool.installed === 'installed'
+      ? 'Skip install; selected tool is already present.'
+      : 'Install according to the current config.',
+  };
+}
+```
+
+### Pattern 3: Shared Summary Formatting
+
+**What:** Keep default terminal output to one grouped `Provenance:` line with counts, up to 3 examples per group, and `+N more`. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**When to use:** Use from `summarizeInventory(report, config?)`; UI components should map returned strings into `<Text>` only. [VERIFIED: src/inventory/summary.ts] [CITED: Context7 /vadimdemedes/ink]
+
+### Anti-Patterns to Avoid
+
+- **Hardcoding per-step provenance text:** violates PROV-04 and risks wizard/config-first drift. [VERIFIED: .planning/REQUIREMENTS.md] [VERIFIED: src/inventory/summary.ts]
+- **Treating `homebrew-direct` as the user-facing category:** it is useful detail/evidence, but PROV-01 asks for "already installed" and "Homebrew dependency" categories. [VERIFIED: .planning/REQUIREMENTS.md] [VERIFIED: src/inventory/provenance.ts]
+- **Marking every `core-tool`/`shell` as OS-provided:** context says OS-provided applies only to known scanner-owned core tools and shells, so classification should check scanner-owned ids such as `core-tool:*` and `shell:*`, not just a broad fallback category. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: src/inventory/scan.ts]
+- **Showing raw warning paths or rc details in the provenance line:** Phase 3 verification requires concise summary output without detailed paths/raw values. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-VERIFICATION.md]
+- **Blocking apply on unknown selected tools:** Phase 04 context explicitly says unknown selected tools do not block apply. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Machine scanning | A new provenance scanner | Existing `InventoryReport` from `scanInventory()` | Phase 04 derives from existing metadata, config intent, and scanner evidence. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: src/inventory/scan.ts] |
+| Metadata matching | Per-step id maps | `getToolMetadata()` and existing registry helpers | Metadata registry is the canonical shared source. [VERIFIED: src/tools/registry.ts] [VERIFIED: .planning/phases/01-tool-metadata-registry/01-CONTEXT.md] |
+| UI wording paths | Separate wizard/config-first text | `summarizeInventory()` plus provenance formatter | Shared summary output is already the architecture and locked by Phase 04. [VERIFIED: src/inventory/summary.ts] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| External command behavior | Real `brew`/`gh`/`op` calls in tests | Mocked helper modules and injected fixture reports | Project rules require external commands to be mocked. [VERIFIED: AGENTS.md] [VERIFIED: tests/unit/inventory-scanner.test.ts] |
+| Secret or rc value explanation | Raw env values or source-line dumps | Count/group output plus structured safe evidence | Project and Phase 3 rules prohibit persisting raw secrets/values in default output. [VERIFIED: AGENTS.md] [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] |
+
+**Key insight:** The provenance helper should be a classifier over already-safe facts, not another discovery mechanism. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: src/inventory/report.ts]
+
+## Common Pitfalls
+
+### Pitfall 1: Selected Precedence Lost
+
+**What goes wrong:** A selected tool already installed by Homebrew is labeled "already installed" or "Homebrew direct" instead of `tilde-managed`. [VERIFIED: src/inventory/provenance.ts]
+
+**Why it happens:** The implementation classifies evidence before config intent. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**How to avoid:** Make selected config intent the first classifier branch and move install evidence into detail/action text. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**Warning signs:** Unit tests fail for selected direct, selected dependency, and selected app-path installed fixtures. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+### Pitfall 2: Early Wizard Inventory Cannot Explain Final Wizard Selection
+
+**What goes wrong:** The early `InventoryStep` tries to explain why a wizard-selected tool was selected before later wizard steps have collected tools, browsers, editors, or AI tools. [VERIFIED: src/modes/wizard.tsx]
+
+**Why it happens:** `InventoryStep` runs at step 1; tools are collected at later steps and `ApplyStep` receives the completed `TildeConfig`. [VERIFIED: src/modes/wizard.tsx] [VERIFIED: src/steps/apply.tsx]
+
+**How to avoid:** Keep early inventory provenance unselected/evidence-oriented, and render config-aware selected provenance in config-first confirmation and final wizard confirmation where `TildeConfig` exists. [VERIFIED: src/modes/config-first.tsx] [VERIFIED: src/steps/apply.tsx]
+
+**Warning signs:** Tests expect `tilde-managed` in the early inventory step without passing a config. [VERIFIED: src/steps/inventory.tsx]
+
+### Pitfall 3: Arbitrary `config.tools` IDs Are Treated Like Registry Tool IDs
+
+**What goes wrong:** Manually entered tools from `ToolsStep` can be arbitrary Homebrew formula/cask names, not guaranteed metadata ids. [VERIFIED: src/steps/tools.tsx]
+
+**Why it happens:** `config.tools` is an array of strings and can include note-taking casks plus free-form user entries. [VERIFIED: src/config/schema.ts] [VERIFIED: src/steps/tools.tsx]
+
+**How to avoid:** For selected ids missing both scanner fact and metadata, create a synthetic unknown selected provenance record with cautious action text, not an OS-provided assumption. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**Warning signs:** Unknown selected tool gets `category: 'core-tool'` and later becomes OS-provided when selected precedence changes. [VERIFIED: src/inventory/provenance.ts]
+
+### Pitfall 4: Manual/App Store Labels Ignore Metadata
+
+**What goes wrong:** Bear or similar manual GUI apps are labeled unknown or unmanaged even though metadata has a manual note and app path. [VERIFIED: src/tools/note-taking-metadata.ts]
+
+**Why it happens:** The classifier only checks Homebrew evidence or installed state. [VERIFIED: src/inventory/provenance.ts]
+
+**How to avoid:** Use `install.manualNote` and `install.appPath` metadata as manual/App Store/manual GUI evidence, and use app-path existence as installed evidence detail. [VERIFIED: src/tools/metadata.ts] [VERIFIED: src/tools/note-taking-metadata.ts]
+
+### Pitfall 5: Warning Output Becomes a Verbose Audit
+
+**What goes wrong:** Provenance output leaks detailed unknown paths, rc source lines, or raw environment values. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-VERIFICATION.md]
+
+**Why it happens:** Summary rendering prints structured evidence directly instead of grouped counts/examples. [VERIFIED: src/inventory/summary.ts]
+
+**How to avoid:** Keep detailed evidence in `ToolProvenance.evidence` and default output in one summary line plus existing warning lines. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+## Code Examples
+
+### Selected Tool IDs from Config
+
+```typescript
+// Source: src/config/schema.ts and current src/inventory/provenance.ts
+function getSelectedToolIds(config?: TildeConfig): Set<string> {
+  const selected = new Set<string>();
+  if (!config) return selected;
+
+  for (const packageManager of config.packageManagers ?? []) selected.add(packageManager);
+  for (const versionManager of config.versionManagers ?? []) selected.add(versionManager.name);
+  for (const tool of config.tools ?? []) selected.add(tool);
+  for (const browser of config.browser?.selected ?? []) selected.add(browser);
+  if (config.browser?.default) selected.add(config.browser.default);
+  if (config.editors?.primary) selected.add(config.editors.primary);
+  for (const editor of config.editors?.additional ?? []) selected.add(editor);
+  for (const aiTool of config.aiTools ?? []) selected.add(aiTool.name);
+
+  return selected;
+}
+```
+
+This mirrors the existing config schema fields and should remain in a shared helper, not UI components. [VERIFIED: src/config/schema.ts] [VERIFIED: src/inventory/provenance.ts]
+
+### Grouped Summary Line
+
+```typescript
+// Source: Phase 04 CONTEXT.md and current src/inventory/provenance.ts
+function formatGroup(group: ProvenanceGroupSummary): string {
+  const examples = group.examples.join(', ');
+  const more = group.remaining > 0 ? `, +${group.remaining} more` : '';
+  return `${DISPLAY_LABELS[group.provenance]} ${group.count}${examples ? ` (${examples}${more})` : ''}`;
+}
+```
+
+This satisfies the locked "up to 3 examples per group and `+N more`" output behavior. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: src/inventory/provenance.ts]
+
+### Vitest Mock Pattern
+
+```typescript
+// Source: Context7 /vitest-dev/vitest/v4.1.6 and tests/unit/inventory-scanner.test.ts
+vi.mock('../../src/tools/registry.js', () => ({
+  getToolMetadata: (id: string) => fixtures[id],
+}));
+```
+
+Use `vi.mock` for metadata/scanner fixtures where needed; Vitest docs confirm module mocks and partial mocks are standard patterns. [CITED: Context7 /vitest-dev/vitest/v4.1.6] [VERIFIED: tests/unit/inventory-scanner.test.ts]
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Phase 2 inventory used installed/missing/unknown plus evidence and avoided final provenance labels. [VERIFIED: .planning/phases/02-machine-inventory-scanner/02-CONTEXT.md] | Phase 4 should derive final provenance labels from those facts. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] | Phase 04 in roadmap. [VERIFIED: .planning/ROADMAP.md] | Do not alter scanner shape unless tests reveal a missing evidence field. [VERIFIED: src/inventory/report.ts] |
+| Phase 3 dotfiles output reported safe counts/findings without final provenance. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] | Phase 4 can preserve dotfile evidence for future audit views but should not add verbose default UI. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] | Phase 04. [VERIFIED: .planning/ROADMAP.md] | Default output stays concise. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| Config-first had inventory summary without selected provenance. [VERIFIED: src/modes/config-first.tsx] | Partial edits now call `summarizeInventory(inventoryReport, phase.config)`. [VERIFIED: src/modes/config-first.tsx] | Interrupted implementation attempt before this research. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] | Planner should validate and finish, not reimplement blindly. [VERIFIED: src/inventory/provenance.ts] |
+
+**Deprecated/outdated:**
+
+- Per-phase prohibition on provenance labels from Phases 2 and 3 is no longer applicable as a blocker in Phase 4; it remains a useful reminder not to put labels into scanners. [VERIFIED: .planning/phases/02-machine-inventory-scanner/02-CONTEXT.md] [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-CONTEXT.md] [VERIFIED: .planning/ROADMAP.md]
+
+## Assumptions Log
+
+All claims in this research were verified against local project files, Phase context, npm registry checks, or Context7 documentation. No `[ASSUMED]` claims are intentionally used. [VERIFIED: research execution]
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| N/A | N/A | N/A | N/A |
+
+## Open Questions
+
+1. **Where should config-aware wizard provenance render?**
+   - What we know: early `InventoryStep` runs before wizard selections, while `ApplyStep` receives completed `TildeConfig`. [VERIFIED: src/modes/wizard.tsx] [VERIFIED: src/steps/apply.tsx]
+   - What's unclear: Phase 04 context says shared summary output in wizard inventory and config-first confirmation, but PROV-03 needs selected/skipped explanations that early inventory cannot know. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] [VERIFIED: .planning/REQUIREMENTS.md]
+   - Recommendation: Plan evidence-only provenance in early wizard inventory and config-aware selected provenance in final wizard confirmation plus config-first confirmation. [VERIFIED: src/modes/wizard.tsx] [VERIFIED: src/modes/config-first.tsx]
+
+2. **Should the internal `ProvenanceLabel` union include `homebrew-direct`?**
+   - What we know: current partial code includes `homebrew-direct`, but PROV-01 names "already installed" and separately names Homebrew dependency. [VERIFIED: src/inventory/provenance.ts] [VERIFIED: .planning/REQUIREMENTS.md]
+   - What's unclear: The internal type can keep evidence-specific labels, but the user-facing output must match phase semantics. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+   - Recommendation: Prefer user-facing provenance labels for `provenance` and store direct/dependency/manual evidence in `detail` or a structured evidence summary. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|-------------|-----------|---------|----------|
+| Node.js | Build and tests | yes [VERIFIED: `node --version`] | v22.22.2 [VERIFIED: `node --version`] | Required by project. [VERIFIED: package.json] |
+| npm | Test scripts and registry verification | yes [VERIFIED: `npm --version`] | 10.9.7 [VERIFIED: `npm --version`] | Required by project. [VERIFIED: package.json] |
+| Vitest | Unit and integration tests | yes [VERIFIED: `./node_modules/.bin/vitest --version`] | 4.1.2 [VERIFIED: `./node_modules/.bin/vitest --version`] | Use npm scripts. [VERIFIED: package.json] |
+| Context7 CLI fallback | Research only | yes [VERIFIED: `command -v ctx7`] | resolved docs with network approval [CITED: Context7] | Not required for implementation. [VERIFIED: research execution] |
+
+**Missing dependencies with no fallback:** none for Phase 04 implementation. [VERIFIED: environment probes]
+
+**Missing dependencies with fallback:** none for Phase 04 implementation. [VERIFIED: environment probes]
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | Vitest 4.1.2. [VERIFIED: `./node_modules/.bin/vitest --version`] |
+| Config file | `vitest.config.ts` for unit tests; integration config exists via npm script. [VERIFIED: vitest.config.ts] [VERIFIED: package.json] |
+| Quick run command | `npm run test -- tests/unit/inventory-provenance.test.ts` [VERIFIED: package.json] |
+| Full suite command | `npm test && npm run test:integration && npm run build && npm run lint` [VERIFIED: package.json] |
+
+### Phase Requirements -> Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|--------------|
+| PROV-01 | Label precedence and categories for selected, direct installed, dependency, manual GUI/App Store, OS-provided, unmanaged, and unknown. [VERIFIED: .planning/REQUIREMENTS.md] | unit | `npm run test -- tests/unit/inventory-provenance.test.ts` | no, Wave 0 gap. [VERIFIED: tests listing] |
+| PROV-02 | One concise grouped provenance line with examples and `+N more` in shared summary output. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] | unit + integration | `npm run test -- tests/unit/inventory-provenance.test.ts tests/unit/inventory-scanner.test.ts` and `npm run test:integration -- tests/integration/wizard-flow.test.tsx tests/integration/config-first.test.ts -t inventory` | partial existing integration files. [VERIFIED: tests/integration/wizard-flow.test.tsx] [VERIFIED: tests/integration/config-first.test.ts] |
+| PROV-03 | Action explanations for install, skip present, leave unmanaged, and proceed cautiously unknown. [VERIFIED: .planning/REQUIREMENTS.md] | unit | `npm run test -- tests/unit/inventory-provenance.test.ts` | no, Wave 0 gap. [VERIFIED: tests listing] |
+| PROV-04 | Derivation uses scanner evidence and metadata, not UI hardcoding. [VERIFIED: .planning/REQUIREMENTS.md] | unit + code review | `npm run test -- tests/unit/inventory-provenance.test.ts` | no, Wave 0 gap. [VERIFIED: tests listing] |
+
+### Sampling Rate
+
+- **Per task commit:** `npm run test -- tests/unit/inventory-provenance.test.ts` plus the touched integration test when UI rendering changes. [VERIFIED: package.json]
+- **Per wave merge:** `npm test && npm run test:integration && npm run build && npm run lint`. [VERIFIED: package.json]
+- **Phase gate:** Full suite green before verification. [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-VERIFICATION.md]
+
+### Wave 0 Gaps
+
+- [ ] `tests/unit/inventory-provenance.test.ts` - covers PROV-01, PROV-03, PROV-04 derivation precedence. [VERIFIED: tests listing]
+- [ ] Extend `tests/integration/config-first.test.ts` - assert provenance summary uses config-aware selected labels and hides verbose evidence. [VERIFIED: tests/integration/config-first.test.ts]
+- [ ] Extend `tests/integration/wizard-flow.test.tsx` or `tests/unit/apply-step` equivalent - assert wizard output gets the same provenance line at a config-aware point. [VERIFIED: tests/integration/wizard-flow.test.tsx] [VERIFIED: src/steps/apply.tsx]
+
+## Security Domain
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|------------------|
+| V2 Authentication | no | Phase 04 does not authenticate users or services. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| V3 Session Management | no | No session state is introduced. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| V4 Access Control | no | Local CLI display phase; no backend resource authorization is introduced. [VERIFIED: .planning/PROJECT.md] |
+| V5 Input Validation | yes | Consume `TildeConfigSchema` output and typed `InventoryReport`; do not parse arbitrary shell text in provenance. [VERIFIED: src/config/schema.ts] [VERIFIED: src/inventory/report.ts] |
+| V6 Cryptography | no | No crypto or secret resolution is introduced. [VERIFIED: AGENTS.md] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+
+### Known Threat Patterns for This Stack
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Raw secret or rc value disclosure in terminal summary | Information Disclosure | Keep default provenance output to categories, counts, labels, and safe action text; never dump raw rc values or env values. [VERIFIED: AGENTS.md] [VERIFIED: .planning/phases/03-dotfiles-discovery-map/03-VERIFICATION.md] |
+| Misleading provenance due to selected/evidence precedence bug | Tampering | Unit-test precedence and keep selected intent as primary label with evidence in detail. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+| Running real external commands in tests | Elevation of Privilege / Tampering | Mock command helpers and inject fixture reports. [VERIFIED: AGENTS.md] [VERIFIED: tests/unit/inventory-scanner.test.ts] |
+| Treating unknown selected tools as blocking errors | Denial of Service | Unknown selected tools should preserve warnings and follow configured action. [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md] |
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- `.planning/phases/04-provenance-summary/04-CONTEXT.md` - locked semantics, phase boundary, output behavior, test plan, interrupted workspace note.
+- `.planning/REQUIREMENTS.md` - PROV-01 through PROV-04.
+- `.planning/ROADMAP.md` - Phase 04 goal and plan slots.
+- `.planning/STATE.md` - accumulated inventory/provenance decisions.
+- `AGENTS.md` - project constraints and workflow rules.
+- `src/inventory/report.ts` - inventory report, facts, evidence, warnings.
+- `src/inventory/scan.ts` - scanner ownership and evidence production.
+- `src/inventory/summary.ts` - shared summary output.
+- `src/inventory/provenance.ts` - interrupted partial provenance helper.
+- `src/steps/inventory.tsx`, `src/modes/config-first.tsx`, `src/modes/wizard.tsx`, `src/steps/apply.tsx` - rendering and config availability points.
+- `src/tools/metadata.ts`, `src/tools/registry.ts`, `src/tools/note-taking-metadata.ts` - metadata fields and lookup helpers.
+- `tests/unit/inventory-scanner.test.ts`, `tests/integration/wizard-flow.test.tsx`, `tests/integration/config-first.test.ts` - existing test patterns and summary coverage.
+
+### Secondary (MEDIUM confidence)
+
+- Context7 `/vadimdemedes/ink` - Ink `Box` and `Text` layout/component docs. [CITED: Context7 /vadimdemedes/ink]
+- Context7 `/vitest-dev/vitest/v4.1.6` - `vi.mock` and module mock docs. [CITED: Context7 /vitest-dev/vitest/v4.1.6]
+- Context7 `/microsoft/typescript/v5.9.3` - NodeNext/Node16 explicit relative import extension behavior. [CITED: Context7 /microsoft/typescript/v5.9.3]
+- npm registry checks for `ink`, `vitest`, and `typescript` latest versions and modified times. [VERIFIED: npm registry]
+
+### Tertiary (LOW confidence)
+
+- None used intentionally. [VERIFIED: research execution]
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Standard stack: HIGH for local versions and commands, MEDIUM for latest registry versions. [VERIFIED: package.json] [VERIFIED: npm registry]
+- Architecture: HIGH because it is derived from current code and phase context. [VERIFIED: src/inventory/report.ts] [VERIFIED: src/modes/wizard.tsx]
+- Pitfalls: HIGH for code-observed issues and phase-locked semantics. [VERIFIED: src/inventory/provenance.ts] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]
+
+**Research date:** 2026-06-20
+**Valid until:** 2026-07-20 for codebase/phase guidance; re-check npm registry versions if planning package upgrades, which this phase should not do. [VERIFIED: package.json] [VERIFIED: .planning/phases/04-provenance-summary/04-CONTEXT.md]

--- a/.planning/phases/04-provenance-summary/04-REVIEW.md
+++ b/.planning/phases/04-provenance-summary/04-REVIEW.md
@@ -1,0 +1,37 @@
+---
+phase: 04-provenance-summary
+status: clean
+depth: standard
+reviewed_at: 2026-06-20T01:15:00Z
+reviewer: codex-inline
+files:
+  - src/inventory/provenance.ts
+  - src/inventory/summary.ts
+  - src/modes/config-first.tsx
+  - src/modes/wizard.tsx
+  - src/steps/apply.tsx
+  - tests/unit/inventory-provenance.test.ts
+  - tests/unit/inventory-scanner.test.ts
+  - tests/integration/config-first.test.ts
+  - tests/integration/wizard-flow.test.tsx
+  - tests/integration/env-capture.test.ts
+---
+
+# Phase 04 Code Review
+
+## Result
+
+Clean. No correctness, security, or maintainability findings requiring changes.
+
+## Notes
+
+- Provenance derivation keeps UI components out of classification logic and preserves structured evidence for future audit views.
+- Config-aware rendering is limited to config-first and final wizard confirmation, while early wizard inventory remains evidence-only.
+- Normal terminal output remains one concise `Provenance:` line plus existing aggregate inventory and warning lines.
+
+## Verification Context
+
+- `npm test` passed.
+- `npm run test:integration` passed.
+- `npm run build` passed.
+- `npm run lint` passed.

--- a/.planning/phases/04-provenance-summary/04-VALIDATION.md
+++ b/.planning/phases/04-provenance-summary/04-VALIDATION.md
@@ -1,0 +1,72 @@
+---
+phase: 04
+slug: provenance-summary
+status: draft
+nyquist_compliant: true
+wave_0_complete: false
+created: 2026-06-20
+---
+
+# Phase 04 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Vitest 4.1.2 |
+| **Config file** | `vitest.config.ts`; integration suite via `vitest.integration.config.ts` |
+| **Quick run command** | `npm run test -- tests/unit/inventory-provenance.test.ts` |
+| **Full suite command** | `npm test && npm run test:integration && npm run build && npm run lint` |
+| **Estimated runtime** | ~60-180 seconds for focused tests; full suite depends on integration breadth |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `npm run test -- tests/unit/inventory-provenance.test.ts`
+- **After every plan wave:** Run touched unit/integration tests, then `npm run build`
+- **Before `$gsd-verify-work`:** Full suite must be green: `npm test && npm run test:integration && npm run build && npm run lint`
+- **Max feedback latency:** 180 seconds for focused feedback
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 04-01-01 | 01 | 1 | PROV-01, PROV-03, PROV-04 | T-04-01 | Default output does not expose raw rc/env values or secrets | unit | `npm run test -- tests/unit/inventory-provenance.test.ts` | ❌ W0 | ⬜ pending |
+| 04-02-01 | 02 | 2 | PROV-02, PROV-03 | T-04-01 | Shared summary stays concise and config-aware | integration | `npm run test:integration -- tests/integration/config-first.test.ts tests/integration/wizard-flow.test.tsx` | ✅ | ⬜ pending |
+| 04-02-02 | 02 | 2 | PROV-02, PROV-04 | T-04-02 | Unknown scanner evidence preserves warnings and does not block apply | unit + integration | `npm run test -- tests/unit/inventory-provenance.test.ts tests/unit/inventory-scanner.test.ts` | partial | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `tests/unit/inventory-provenance.test.ts` — covers derivation precedence for managed, installed, dependency, manual GUI/App Store, OS-provided, unmanaged, and unknown.
+- [ ] Config-first integration assertion — provenance line uses current config intent and hides verbose evidence.
+- [ ] Wizard integration assertion — wizard output receives the shared provenance line at a config-aware point.
+
+---
+
+## Manual-Only Verifications
+
+All phase behaviors have automated verification.
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references
+- [x] No watch-mode flags
+- [x] Feedback latency < 180s for focused tests
+- [x] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/src/inventory/provenance.ts
+++ b/src/inventory/provenance.ts
@@ -1,0 +1,219 @@
+import type { TildeConfig } from '../config/schema.js';
+import { getToolMetadata } from '../tools/registry.js';
+import type { InventoryEvidence, InventoryReport, InventoryToolCategory, InventoryToolFact } from './report.js';
+
+export type ProvenanceLabel =
+  | 'tilde-managed'
+  | 'already-installed'
+  | 'homebrew-dependency'
+  | 'manual-install'
+  | 'manual-gui'
+  | 'os-provided'
+  | 'unknown';
+
+export interface ToolProvenance {
+  toolId: string;
+  label: string;
+  category: InventoryToolCategory;
+  installed: InventoryToolFact['installed'];
+  selected: boolean;
+  provenance: ProvenanceLabel;
+  detail: string;
+  action: string;
+  evidence: InventoryEvidence[];
+  warningIds: string[];
+}
+
+export interface ProvenanceGroupSummary {
+  provenance: ProvenanceLabel;
+  count: number;
+  examples: string[];
+  remaining: number;
+}
+
+export const PROVENANCE_LABELS: Record<ProvenanceLabel, string> = {
+  'tilde-managed': 'tilde-managed',
+  'already-installed': 'already installed',
+  'homebrew-dependency': 'Homebrew dependency',
+  'manual-install': 'manual install',
+  'manual-gui': 'manual GUI',
+  'os-provided': 'OS-provided',
+  unknown: 'unknown',
+};
+
+const PROVENANCE_ORDER: ProvenanceLabel[] = [
+  'tilde-managed',
+  'already-installed',
+  'homebrew-dependency',
+  'manual-install',
+  'manual-gui',
+  'os-provided',
+  'unknown',
+];
+
+export function deriveInventoryProvenance(
+  report: InventoryReport,
+  config?: TildeConfig
+): ToolProvenance[] {
+  const selectedToolIds = getSelectedToolIds(config);
+  const factsById = new Map(report.tools.map(tool => [tool.toolId, tool]));
+
+  for (const selectedToolId of selectedToolIds) {
+    if (!factsById.has(selectedToolId)) {
+      const metadata = getToolMetadata(selectedToolId);
+      factsById.set(selectedToolId, {
+        toolId: selectedToolId,
+        label: metadata?.label ?? selectedToolId,
+        category: metadata?.category ?? 'core-tool',
+        installed: 'unknown',
+        evidence: [{ type: 'inconclusive', source: 'scanner', reason: 'No inventory fact was collected for this selected tool.' }],
+        warningIds: [],
+      });
+    }
+  }
+
+  return [...factsById.values()].map(tool => {
+    const selected = selectedToolIds.has(tool.toolId);
+    const provenance = classifyToolProvenance(tool, selected);
+
+    return {
+      toolId: tool.toolId,
+      label: tool.label,
+      category: tool.category,
+      installed: tool.installed,
+      selected,
+      provenance,
+      detail: buildDetail(tool, provenance, selected),
+      action: buildAction(tool, provenance, selected),
+      evidence: tool.evidence,
+      warningIds: tool.warningIds,
+    };
+  });
+}
+
+export function summarizeProvenanceGroups(
+  provenance: ToolProvenance[],
+  maxExamples = 3
+): ProvenanceGroupSummary[] {
+  return PROVENANCE_ORDER.map(label => {
+    const tools = provenance.filter(tool => tool.provenance === label);
+    return {
+      provenance: label,
+      count: tools.length,
+      examples: tools.slice(0, maxExamples).map(tool => tool.label),
+      remaining: Math.max(0, tools.length - maxExamples),
+    };
+  }).filter(group => group.count > 0);
+}
+
+export function formatProvenanceSummaryLine(report: InventoryReport, config?: TildeConfig): string {
+  const groups = summarizeProvenanceGroups(deriveInventoryProvenance(report, config));
+  const formattedGroups = groups.map(group => {
+    const examples = group.examples.join(', ');
+    const more = group.remaining > 0 ? `, +${group.remaining} more` : '';
+    return `${PROVENANCE_LABELS[group.provenance]} ${group.count}${examples ? ` (${examples}${more})` : ''}`;
+  });
+
+  return `Provenance: ${formattedGroups.length > 0 ? formattedGroups.join('; ') : 'none'}`;
+}
+
+function classifyToolProvenance(tool: InventoryToolFact, selected: boolean): ProvenanceLabel {
+  if (selected) return 'tilde-managed';
+  if (hasHomebrewEvidence(tool.evidence, 'dependency')) return 'homebrew-dependency';
+  if (hasHomebrewEvidence(tool.evidence, 'direct')) return 'already-installed';
+  if (isScannerOwnedOsTool(tool)) return 'os-provided';
+  if (hasExistingAppPathEvidence(tool.evidence)) return 'manual-gui';
+  if (tool.installed === 'installed' && getToolMetadata(tool.toolId)?.install?.manualNote) return 'manual-install';
+  if (tool.installed === 'installed') return 'already-installed';
+  return 'unknown';
+}
+
+function buildDetail(tool: InventoryToolFact, provenance: ProvenanceLabel, selected: boolean): string {
+  const formulaEvidence = tool.evidence.find(evidence => evidence.type === 'homebrew-formula');
+  if (formulaEvidence?.type === 'homebrew-formula') {
+    return selected
+      ? `Selected by config; Homebrew formula ${formulaEvidence.id} is already present as ${formulaEvidence.requestStatus}.`
+      : `Homebrew formula ${formulaEvidence.id} is present as ${formulaEvidence.requestStatus}.`;
+  }
+
+  const caskEvidence = tool.evidence.find(evidence => evidence.type === 'homebrew-cask');
+  if (caskEvidence?.type === 'homebrew-cask') {
+    return selected
+      ? `Selected by config; Homebrew cask ${caskEvidence.id} is already present.`
+      : `Homebrew cask ${caskEvidence.id} is present.`;
+  }
+
+  const appEvidence = tool.evidence.find(evidence => evidence.type === 'app-path');
+  if (appEvidence?.type === 'app-path') {
+    return appEvidence.exists
+      ? `Application bundle exists at ${appEvidence.path}.`
+      : `Application bundle was not found at ${appEvidence.path}.`;
+  }
+
+  const commandEvidence = tool.evidence.find(evidence => evidence.type === 'command');
+  if (commandEvidence?.type === 'command') {
+    const version = commandEvidence.version ? ` (${commandEvidence.version})` : '';
+    return `Detected command ${commandEvidence.command}${version}.`;
+  }
+
+  const shellEvidence = tool.evidence.find(evidence => evidence.type === 'shell');
+  if (shellEvidence?.type === 'shell') {
+    return `Detected shell ${shellEvidence.name}.`;
+  }
+
+  const manualNote = getToolMetadata(tool.toolId)?.install?.manualNote;
+  if (manualNote) return manualNote;
+
+  if (provenance === 'os-provided') return 'Known scanner-owned core tool or shell.';
+  if (provenance === 'already-installed') return 'Installed, but not selected by current config.';
+  return 'Scanner evidence is insufficient or inconclusive.';
+}
+
+function buildAction(tool: InventoryToolFact, provenance: ProvenanceLabel, selected: boolean): string {
+  if (selected && tool.installed === 'installed') {
+    const dependencyEvidence = hasHomebrewEvidence(tool.evidence, 'dependency');
+    return dependencyEvidence
+      ? 'Skip install; selected tool is already present as a dependency.'
+      : 'Skip install; selected tool is already present.';
+  }
+
+  if (selected && tool.installed === 'missing') return 'Install according to the current config.';
+  if (selected) return 'Proceed cautiously with configured action; inventory could not confirm current state.';
+  if (provenance === 'unknown') return 'Leave present state unchanged; scanner evidence is inconclusive.';
+  return 'Leave present and unmanaged.';
+}
+
+function getSelectedToolIds(config?: TildeConfig): Set<string> {
+  const selected = new Set<string>();
+  if (!config) return selected;
+
+  for (const packageManager of config.packageManagers ?? []) selected.add(packageManager);
+  for (const versionManager of config.versionManagers ?? []) selected.add(versionManager.name);
+  for (const tool of config.tools ?? []) selected.add(tool);
+  for (const browser of config.browser?.selected ?? []) selected.add(browser);
+  if (config.browser?.default) selected.add(config.browser.default);
+  if (config.editors?.primary) selected.add(config.editors.primary);
+  for (const editor of config.editors?.additional ?? []) selected.add(editor);
+  for (const aiTool of config.aiTools ?? []) selected.add(aiTool.name);
+
+  return selected;
+}
+
+function hasHomebrewEvidence(evidence: InventoryEvidence[], requestStatus: 'direct' | 'dependency'): boolean {
+  return evidence.some(item => item.type === 'homebrew-formula' && item.requestStatus === requestStatus) ||
+    evidence.some(item => item.type === 'homebrew-cask' && item.requestStatus === requestStatus);
+}
+
+function hasExistingAppPathEvidence(evidence: InventoryEvidence[]): boolean {
+  return evidence.some(item => item.type === 'app-path' && item.exists);
+}
+
+function isScannerOwnedOsTool(tool: InventoryToolFact): boolean {
+  if (tool.installed !== 'installed') return false;
+  if (!tool.toolId.startsWith('shell:') && !tool.toolId.startsWith('core-tool:')) return false;
+
+  return tool.evidence.some(item =>
+    item.type === 'shell' ||
+    (item.type === 'command' && item.outcome === 'succeeded')
+  );
+}

--- a/src/inventory/summary.ts
+++ b/src/inventory/summary.ts
@@ -1,16 +1,19 @@
 import type { InventoryReport, InventoryToolFact } from './report.js';
+import type { TildeConfig } from '../config/schema.js';
+import { formatProvenanceSummaryLine } from './provenance.js';
 
 export function getInstalledKnownToolFacts(report: InventoryReport): InventoryToolFact[] {
   return report.tools.filter(tool => tool.installed === 'installed' && tool.category !== 'shell' && tool.category !== 'core-tool');
 }
 
-export function summarizeInventory(report: InventoryReport): string[] {
+export function summarizeInventory(report: InventoryReport, config?: TildeConfig): string[] {
   const installedKnownTools = getInstalledKnownToolFacts(report);
   const installedKnownToolSummary = installedKnownTools.length > 0
     ? installedKnownTools.map(tool => tool.label).join(', ')
     : 'none';
   const lines = [
     `Known installed tools: ${installedKnownToolSummary}`,
+    formatProvenanceSummaryLine(report, config),
     `Homebrew formulae: ${report.homebrew.directFormulaeCount} direct, ${report.homebrew.dependencyFormulaeCount} dependencies, ${report.homebrew.unknownFormulaeCount} unknown`,
     `Homebrew casks: ${report.homebrew.installedCasksCount} installed, ${report.homebrew.unmatchedCasksCount} unmatched`,
     `Dotfiles: ${report.dotfiles.counts.knownFiles} known, ${report.dotfiles.counts.unknownFiles} unknown, ${report.dotfiles.counts.warnings} warnings`,

--- a/src/modes/config-first.tsx
+++ b/src/modes/config-first.tsx
@@ -186,7 +186,7 @@ export function ConfigFirstMode({ configPath, inventory, inventoryState, onCompl
           <Box flexDirection="column">
             <Text bold>{inventoryHeading}</Text>
             <Box marginTop={1} flexDirection="column">
-              {summarizeInventory(inventoryReport).map(line => (
+              {summarizeInventory(inventoryReport, phase.config).map(line => (
                 <Text
                   key={line}
                   color={line.startsWith('Warning') ? 'yellow' : 'green'}

--- a/src/modes/wizard.tsx
+++ b/src/modes/wizard.tsx
@@ -574,6 +574,7 @@ export function Wizard({ initialStep = 0, initialConfig = {}, inventory, invento
         {activeStep === 12 && (
           <ApplyStep
             config={config as TildeConfig}
+            inventory={inventoryReport}
             onBack={onBack}
             onComplete={() => void advance({}, [])}
           />

--- a/src/steps/apply.tsx
+++ b/src/steps/apply.tsx
@@ -17,16 +17,19 @@ import { ConfigSummary } from '../ui/config-summary.js';
 import { installAll } from '../installer/index.js';
 import { writeAll } from '../dotfiles/writer.js';
 import { pluginRegistry } from '../plugins/registry.js';
+import type { InventoryReport } from '../inventory/report.js';
+import { summarizeInventory } from '../inventory/summary.js';
 
 interface Props {
   config: TildeConfig;
+  inventory?: InventoryReport;
   onComplete: () => void;
   onBack?: () => void;
 }
 
 type Phase = 'confirm' | 'applying' | 'done' | 'error';
 
-export function ApplyStep({ config, onComplete, onBack }: Props) {
+export function ApplyStep({ config, inventory, onComplete, onBack }: Props) {
   const [phase, setPhase] = useState<Phase>('confirm');
   const [progress, setProgress] = useState<string[]>([]);
   const [errorMsg, setErrorMsg] = useState('');
@@ -107,6 +110,18 @@ export function ApplyStep({ config, onComplete, onBack }: Props) {
     <Box flexDirection="column">
       <Text bold>Apply Configuration</Text>
       <Text dimColor>Review your setup before tilde applies it to this machine</Text>
+      {inventory && (
+        <Box marginTop={1} flexDirection="column">
+          {summarizeInventory(inventory, config).map(line => (
+            <Text
+              key={line}
+              color={line.startsWith('Warning') ? 'yellow' : 'green'}
+            >
+              {line}
+            </Text>
+          ))}
+        </Box>
+      )}
       <Box marginTop={1}>
         <ConfigSummary config={config} />
       </Box>

--- a/tests/integration/config-first.test.ts
+++ b/tests/integration/config-first.test.ts
@@ -181,15 +181,16 @@ describe('ConfigFirstMode integration', () => {
     expect(inventoryIndex).toBeLessThan(configIndex);
     const inventoryBlock = frame.slice(inventoryIndex, configIndex);
     expect(inventoryBlock).toContain('Known installed tools: Homebrew');
+    expect(inventoryBlock).toContain('Provenance: tilde-managed 3 (Homebrew, ripgrep, fd)');
     expect(inventoryBlock).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
     expect(inventoryBlock).toContain('Dotfiles:');
     expect(inventoryBlock).toContain('Dotfile findings: 1 known hooks, 2 unknown rc findings');
     expect(inventoryBlock).toContain('Warnings:');
     expect(inventoryBlock).toContain('Warning: Homebrew direct/dependency status is unavailable.');
-    expect(inventoryBlock).not.toContain('ripgrep');
     expect(inventoryBlock).not.toContain('alias gs=');
     expect(inventoryBlock).not.toContain('eval "$(direnv hook zsh)"');
     expect(inventoryBlock).not.toContain('~/.private-aliases');
+    expect((inventoryBlock.match(/Provenance:/g) ?? []).length).toBe(1);
   });
 
   it('withholds apply choices while inventory is loading', async () => {

--- a/tests/integration/env-capture.test.ts
+++ b/tests/integration/env-capture.test.ts
@@ -3,7 +3,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import type { InventoryReport } from '../../src/inventory/report.js';
+import { createEmptyInventoryReport, type InventoryReport } from '../../src/inventory/report.js';
 
 vi.mock('../../src/utils/exec.js', () => ({
   run: vi.fn().mockResolvedValue({ stdout: 'git\nnodejs\nnpm\n', stderr: '', exitCode: 0 }),
@@ -111,6 +111,7 @@ describe('env-capture integration', () => {
 describe('inventory integration', () => {
   function createInventoryFixture(): InventoryReport {
     return {
+      ...createEmptyInventoryReport(),
       tools: [
         {
           toolId: 'homebrew',

--- a/tests/integration/wizard-flow.test.tsx
+++ b/tests/integration/wizard-flow.test.tsx
@@ -173,7 +173,7 @@ describe('Wizard flow integration', () => {
     const { lastFrame } = render(React.createElement(ConfigDetectionStep, { onComplete, onExit }));
 
     // Wait for async config scan
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise(resolve => setTimeout(resolve, 300));
 
     // Should NOT have auto-advanced — should show a prompt
     expect(onComplete).not.toHaveBeenCalled();

--- a/tests/integration/wizard-flow.test.tsx
+++ b/tests/integration/wizard-flow.test.tsx
@@ -3,6 +3,7 @@ import { Text } from 'ink';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createEmptyInventoryReport, type InventoryReport, type InventoryScanState } from '../../src/inventory/report.js';
+import type { TildeConfig } from '../../src/config/schema.js';
 
 const { mockScanInventory } = vi.hoisted(() => ({
   mockScanInventory: vi.fn(),
@@ -375,6 +376,8 @@ describe('Wizard flow integration', () => {
     expect(frame).not.toContain('Environment Capture');
     expect(frame).toContain('Inventory scan complete');
     expect(frame).toContain('Known installed tools:');
+    expect(frame).toContain('Provenance: already installed');
+    expect(frame).not.toContain('tilde-managed');
     expect(frame).toContain('Dotfiles:');
   });
 
@@ -402,6 +405,7 @@ describe('Wizard flow integration', () => {
     const frame = lastFrame() ?? '';
     expect(frame).toContain('Inventory scan complete');
     expect(frame).toContain('Known installed tools:');
+    expect((frame.match(/Provenance:/g) ?? []).length).toBe(1);
     expect(frame).toContain('Homebrew formulae: 1 direct, 1 dependencies, 0 unknown');
     expect(frame).toContain('Dotfile findings: 1 known hooks, 2 unknown rc findings');
     expect(frame).toContain('Warnings:');
@@ -410,6 +414,66 @@ describe('Wizard flow integration', () => {
     expect(frame).not.toContain('alias gs=');
     expect(frame).not.toContain('eval "$(direnv hook zsh)"');
     expect(frame).not.toContain('~/.private-aliases');
+  });
+
+  it('final apply confirmation renders config-aware inventory provenance before choices', async () => {
+    const { ApplyStep } = await import('../../src/steps/apply.js');
+    const onComplete = vi.fn();
+    const onBack = vi.fn();
+    const config: TildeConfig = {
+      $schema: 'https://thingstead.io/tilde/config-schema/v1.json',
+      version: '1',
+      schemaVersion: '1.6',
+      os: 'macos',
+      shell: 'zsh',
+      packageManagers: ['homebrew'],
+      versionManagers: [],
+      languages: [],
+      workspaceRoot: '~/Developer',
+      dotfilesRepo: '~/Developer/personal/dotfiles',
+      contexts: [{
+        label: 'personal',
+        path: '~/Developer/personal',
+        git: { name: 'Test User', email: 'test@example.com' },
+        authMethod: 'gh-cli',
+        envVars: [],
+        languageBindings: [],
+      }],
+      tools: ['unknown-selected-tool'],
+      configurations: {
+        git: true,
+        vscode: false,
+        aliases: false,
+        osDefaults: false,
+        direnv: true,
+      },
+      accounts: [],
+      secretsBackend: '1password',
+      browser: { selected: [], default: null },
+      editors: { primary: 'vscode', additional: [] },
+      aiTools: [],
+    };
+
+    const { lastFrame } = render(
+      React.createElement(ApplyStep, {
+        config,
+        inventory: createInventoryFixture(),
+        onComplete,
+        onBack,
+      } as React.ComponentProps<typeof ApplyStep>)
+    );
+
+    const frame = lastFrame() ?? '';
+    const provenanceIndex = frame.indexOf('Provenance:');
+    const configIndex = frame.indexOf('Configuration Summary');
+    const choicesIndex = frame.indexOf('Apply & Finish');
+
+    expect(provenanceIndex).toBeGreaterThanOrEqual(0);
+    expect(configIndex).toBeGreaterThan(provenanceIndex);
+    expect(choicesIndex).toBeGreaterThan(configIndex);
+    expect(frame).toContain('tilde-managed 3 (Homebrew, Visual Studio Code, unknown-selected-tool)');
+    expect(frame).toContain('Apply & Finish');
+    expect(frame).toContain('Finish');
   });
 
   it('inventory wizard step shows startup scan failure warnings without blocking rendering', async () => {

--- a/tests/unit/inventory-dotfiles.test.ts
+++ b/tests/unit/inventory-dotfiles.test.ts
@@ -334,4 +334,110 @@ describe('inventory dotfile scanner', () => {
     expect(serialized).not.toContain('op://Personal/item/field');
     expect(serialized).not.toContain('tool command');
   });
+
+  it('parses shell rc files into safe structured findings without raw values', () => {
+    const findings = parseShellRcFindings(join(tmpHome, '.zshrc'), rcFixture);
+    const serialized = JSON.stringify(findings);
+
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'alias',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'gs' }),
+      }),
+      expect.objectContaining({
+        kind: 'function',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'workon' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'EDITOR', valueKind: 'literal' }),
+      }),
+      expect.objectContaining({
+        kind: 'path-edit',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'PATH', valueKind: 'reference' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'GH_TOKEN', valueKind: 'secret-like' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'OP_REF', valueKind: 'secret-like' }),
+      }),
+      expect.objectContaining({
+        kind: 'export',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ name: 'GENERATED', valueKind: 'command-derived' }),
+      }),
+      expect.objectContaining({
+        kind: 'source',
+        classification: 'unknown',
+        safeDetails: expect.objectContaining({ target: '~/.aliases' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['direnv'],
+        safeDetails: expect.objectContaining({ toolId: 'direnv' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['vfox'],
+        safeDetails: expect.objectContaining({ toolId: 'vfox' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['1password'],
+        safeDetails: expect.objectContaining({ toolId: '1password' }),
+      }),
+      expect.objectContaining({
+        kind: 'tool-init-hook',
+        classification: 'known',
+        toolIds: ['homebrew'],
+        safeDetails: expect.objectContaining({ toolId: 'homebrew' }),
+      }),
+    ]));
+
+    expect(serialized).not.toContain('git status');
+    expect(serialized).not.toContain('cd ~/work');
+    expect(serialized).not.toContain('nvim');
+    expect(serialized).not.toContain('ghp_secret');
+    expect(serialized).not.toContain('op://Personal/item/field');
+    expect(serialized).not.toContain('tool command');
+    expect(serialized).not.toContain('/opt/homebrew/bin/brew shellenv');
+  });
+
+  it('integrates rc findings into dotfile map counts separately from path findings', async () => {
+    const map = await scanDotfileMap({ homeDir: tmpHome, warnings });
+    const zshrc = fileByPath(map, join(tmpHome, '.zshrc'));
+
+    expect(zshrc).toEqual(expect.objectContaining({
+      state: 'mixed',
+      toolIds: ['1password', 'direnv', 'homebrew', 'vfox'],
+      findings: expect.arrayContaining([
+        expect.objectContaining({ kind: 'alias', classification: 'unknown' }),
+        expect.objectContaining({ kind: 'function', classification: 'unknown' }),
+        expect.objectContaining({ kind: 'source', classification: 'unknown' }),
+        expect.objectContaining({ kind: 'tool-init-hook', classification: 'known', toolIds: ['direnv'] }),
+      ]),
+    }));
+    expect(map.counts).toEqual(expect.objectContaining({
+      knownFindingsCount: 4,
+      unknownFindingsCount: expect.any(Number),
+    }));
+    expect((map.counts as { unknownFindingsCount?: number }).unknownFindingsCount).toBeGreaterThanOrEqual(8);
+
+    const serialized = JSON.stringify(map);
+    expect(serialized).not.toContain('ghp_secret');
+    expect(serialized).not.toContain('op://Personal/item/field');
+    expect(serialized).not.toContain('tool command');
+  });
 });

--- a/tests/unit/inventory-provenance.test.ts
+++ b/tests/unit/inventory-provenance.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import type { TildeConfig } from '../../src/config/schema.js';
+import { createEmptyInventoryReport, type InventoryReport, type InventoryToolFact } from '../../src/inventory/report.js';
+import {
+  deriveInventoryProvenance,
+  formatProvenanceSummaryLine,
+  summarizeProvenanceGroups,
+} from '../../src/inventory/provenance.js';
+
+describe('inventory provenance', () => {
+  it('keeps selected tools tilde-managed while preserving installed evidence detail', () => {
+    const report = reportWithTools([
+      fact({
+        toolId: 'homebrew',
+        label: 'Homebrew',
+        category: 'package-manager',
+        evidence: [{ type: 'homebrew-formula', id: 'brew', requestStatus: 'direct' }],
+      }),
+      fact({
+        toolId: 'vfox',
+        label: 'vfox',
+        category: 'version-manager',
+        evidence: [{ type: 'homebrew-formula', id: 'vfox', requestStatus: 'dependency' }],
+      }),
+      fact({
+        toolId: 'vscode',
+        label: 'Visual Studio Code',
+        category: 'editor',
+        evidence: [{ type: 'app-path', path: '/Applications/Visual Studio Code.app', exists: true }],
+      }),
+      fact({
+        toolId: 'git',
+        label: 'GitHub CLI',
+        category: 'account-connector',
+        evidence: [{ type: 'command', command: 'gh', outcome: 'succeeded', version: '2.0.0' }],
+      }),
+    ]);
+
+    const provenance = deriveInventoryProvenance(report, config({
+      packageManagers: ['homebrew'],
+      versionManagers: [{ name: 'vfox' }],
+      editors: { primary: 'vscode', additional: [] },
+      tools: ['git'],
+    }));
+
+    expect(provenance).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        toolId: 'homebrew',
+        provenance: 'tilde-managed',
+        detail: expect.stringContaining('direct'),
+        action: expect.stringContaining('Skip install'),
+      }),
+      expect.objectContaining({
+        toolId: 'vfox',
+        provenance: 'tilde-managed',
+        detail: expect.stringContaining('dependency'),
+        action: expect.stringContaining('dependency'),
+      }),
+      expect.objectContaining({
+        toolId: 'vscode',
+        provenance: 'tilde-managed',
+        detail: expect.stringContaining('Application bundle exists'),
+      }),
+      expect.objectContaining({
+        toolId: 'git',
+        provenance: 'tilde-managed',
+        detail: expect.stringContaining('command gh'),
+      }),
+    ]));
+  });
+
+  it('labels unselected direct and dependency Homebrew facts with user-facing provenance', () => {
+    const report = reportWithTools([
+      fact({
+        toolId: 'ripgrep',
+        label: 'ripgrep',
+        category: 'core-tool',
+        evidence: [{ type: 'homebrew-formula', id: 'ripgrep', requestStatus: 'direct' }],
+      }),
+      fact({
+        toolId: 'openssl',
+        label: 'OpenSSL',
+        category: 'core-tool',
+        evidence: [{ type: 'homebrew-formula', id: 'openssl@3', requestStatus: 'dependency' }],
+      }),
+    ]);
+
+    const provenance = deriveInventoryProvenance(report);
+
+    expect(provenance).toEqual([
+      expect.objectContaining({
+        toolId: 'ripgrep',
+        provenance: 'already-installed',
+        detail: expect.stringContaining('direct'),
+      }),
+      expect.objectContaining({
+        toolId: 'openssl',
+        provenance: 'homebrew-dependency',
+        detail: expect.stringContaining('dependency'),
+      }),
+    ]);
+  });
+
+  it('uses metadata-backed manual GUI evidence and scanner-owned OS-provided labels only where appropriate', () => {
+    const report = reportWithTools([
+      fact({
+        toolId: 'bear',
+        label: 'Bear',
+        category: 'note-taking',
+        evidence: [{ type: 'app-path', path: '/Applications/Bear.app', exists: true }],
+      }),
+      fact({
+        toolId: 'shell:zsh',
+        label: 'zsh',
+        category: 'shell',
+        evidence: [{ type: 'shell', name: 'zsh', source: 'process-env' }],
+      }),
+      fact({
+        toolId: 'core-tool:node',
+        label: 'node',
+        category: 'core-tool',
+        evidence: [{ type: 'command', command: 'node', outcome: 'succeeded', version: '22.0.0' }],
+      }),
+      fact({
+        toolId: 'custom-core-tool',
+        label: 'Custom Core Tool',
+        category: 'core-tool',
+        evidence: [{ type: 'command', command: 'custom-core-tool', outcome: 'succeeded' }],
+      }),
+    ]);
+
+    const provenance = deriveInventoryProvenance(report);
+
+    expect(provenance).toEqual(expect.arrayContaining([
+      expect.objectContaining({ toolId: 'bear', provenance: 'manual-gui' }),
+      expect.objectContaining({ toolId: 'shell:zsh', provenance: 'os-provided' }),
+      expect.objectContaining({ toolId: 'core-tool:node', provenance: 'os-provided' }),
+      expect.objectContaining({ toolId: 'custom-core-tool', provenance: 'already-installed' }),
+    ]));
+  });
+
+  it('keeps inconclusive and selected missing facts non-blocking with warning ids preserved', () => {
+    const report = reportWithTools([
+      fact({
+        toolId: 'unknown-tool',
+        label: 'Unknown Tool',
+        category: 'core-tool',
+        installed: 'unknown',
+        evidence: [{
+          type: 'inconclusive',
+          source: 'scanner',
+          reason: 'No matching scanner evidence.',
+          warningId: 'scanner:unknown-tool',
+        }],
+        warningIds: ['scanner:unknown-tool'],
+      }),
+    ]);
+
+    const provenance = deriveInventoryProvenance(report, config({ tools: ['missing-selected-tool'] }));
+
+    expect(provenance).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        toolId: 'unknown-tool',
+        provenance: 'unknown',
+        warningIds: ['scanner:unknown-tool'],
+        action: expect.stringContaining('Leave'),
+      }),
+      expect.objectContaining({
+        toolId: 'missing-selected-tool',
+        provenance: 'tilde-managed',
+        installed: 'unknown',
+        action: expect.stringContaining('Proceed cautiously'),
+      }),
+    ]));
+  });
+
+  it('groups summaries with at most three examples and a remaining count', () => {
+    const report = reportWithTools([
+      fact({ toolId: 'tool-a', label: 'Tool A', category: 'core-tool', evidence: [{ type: 'command', command: 'a', outcome: 'succeeded' }] }),
+      fact({ toolId: 'tool-b', label: 'Tool B', category: 'core-tool', evidence: [{ type: 'command', command: 'b', outcome: 'succeeded' }] }),
+      fact({ toolId: 'tool-c', label: 'Tool C', category: 'core-tool', evidence: [{ type: 'command', command: 'c', outcome: 'succeeded' }] }),
+      fact({ toolId: 'tool-d', label: 'Tool D', category: 'core-tool', evidence: [{ type: 'command', command: 'd', outcome: 'succeeded' }] }),
+    ]);
+
+    const groups = summarizeProvenanceGroups(deriveInventoryProvenance(report));
+    const installedGroup = groups.find(group => group.provenance === 'already-installed');
+    const line = formatProvenanceSummaryLine(report);
+
+    expect(installedGroup).toEqual(expect.objectContaining({
+      count: 4,
+      examples: ['Tool A', 'Tool B', 'Tool C'],
+      remaining: 1,
+    }));
+    expect(line).toContain('already installed 4 (Tool A, Tool B, Tool C, +1 more)');
+  });
+});
+
+function reportWithTools(tools: InventoryToolFact[]): InventoryReport {
+  return {
+    ...createEmptyInventoryReport('/Users/tester'),
+    tools,
+  };
+}
+
+function fact(overrides: Partial<InventoryToolFact> & Pick<InventoryToolFact, 'toolId' | 'label' | 'category' | 'evidence'>): InventoryToolFact {
+  return {
+    installed: 'installed',
+    warningIds: [],
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<TildeConfig> = {}): TildeConfig {
+  return {
+    $schema: 'https://thingstead.io/tilde/config-schema/v1.json',
+    version: '1',
+    schemaVersion: '1.6',
+    os: 'macos',
+    shell: 'zsh',
+    packageManagers: [],
+    versionManagers: [],
+    languages: [],
+    workspaceRoot: '~/Developer',
+    dotfilesRepo: '~/dotfiles',
+    contexts: [{ label: 'work', path: '~/Developer' }],
+    tools: [],
+    configurations: {},
+    accounts: [],
+    secretsBackend: 'env-only',
+    browser: { selected: [], default: null },
+    editors: { primary: null, additional: [] },
+    aiTools: [],
+    ...overrides,
+  };
+}

--- a/tests/unit/inventory-scanner.test.ts
+++ b/tests/unit/inventory-scanner.test.ts
@@ -32,7 +32,15 @@ vi.mock('../../src/utils/env-detection.js', () => ({
 }));
 
 vi.mock('../../src/tools/registry.js', () => ({
-  allToolMetadata: [
+  allToolMetadata: MOCK_TOOL_METADATA,
+  getToolMetadata: (id: string) => MOCK_TOOL_METADATA.find(tool => tool.id === id),
+  getToolsByConfigPath: (path: string) => path === '~/.config/test-cli' || path.startsWith('~/.config/test-cli/')
+    ? [MOCK_TOOL_METADATA.find(tool => tool.id === 'test-cli')]
+    : [],
+  getToolsByDotfilePath: () => [],
+}));
+
+const MOCK_TOOL_METADATA = [
     {
       id: 'homebrew',
       label: 'Homebrew',
@@ -88,24 +96,7 @@ vi.mock('../../src/tools/registry.js', () => ({
         },
       },
     },
-  ],
-  getToolsByConfigPath: (path: string) => path === '~/.config/test-cli' || path.startsWith('~/.config/test-cli/')
-    ? [{
-      id: 'test-cli',
-      label: 'Test CLI',
-      category: 'package-manager',
-      supportedPlatforms: ['darwin'],
-      source: 'first-party',
-      install: {
-        homebrew: {
-          formula: 'test-cli',
-        },
-      },
-      configPaths: ['~/.config/test-cli'],
-    }]
-    : [],
-  getToolsByDotfilePath: () => [],
-}));
+  ];
 
 vi.mock('node:fs/promises', async () => {
   const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');


### PR DESCRIPTION
## Summary

Adds the Phase 04 provenance summary layer stacked on Phase 03.

This includes evidence-backed provenance categories, config-aware tilde-managed precedence, concise grouped summary formatting, config-first and wizard confirmation rendering, integration fixture stabilization, and GSD review/verification artifacts.

## Validation

- Phase 04 execution and review artifacts are included in `.planning/phases/04-provenance-summary/`
- Clean stacked branch rebuilt on `gsd/pr-phase-03-dotfiles-discovery-map`

## Stack

Stacked after #127. Phase 05 should target this branch.