### PR TITLE
[codex] Release machine inventory updates and narrow CI branch triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
     paths-ignore:
       - 'specs/**'
       - 'terraform/**'


### PR DESCRIPTION
## Summary
- Add an empty `feat:` commit so semantic-release creates a minor release for the already-merged machine inventory/provenance work.
- Change CI push triggers from all branches to `main` only, while keeping PR checks for `main`.

## Why
The release pipeline now authenticates successfully, but semantic-release saw only non-release squash commit titles after `v1.7.0` and correctly reported no relevant changes. The empty `feat:` commit gives semantic-release an explicit release signal.

The CI workflow previously ran on every branch push and again on PRs. This keeps PR validation and adds one post-merge run on `main` without branch-push duplicates.

## Validation
- `git diff --check`
- Verified the successful release run reported `Analysis of 10 commits complete: no release`, confirming this is a commit-analysis issue rather than an auth/build failure.