### PR TITLE
[codex] Backfill missing GSD phase artifacts

### DIFF
--- a/.planning/phases/04-provenance-summary/04-DISCUSSION-LOG.md
+++ b/.planning/phases/04-provenance-summary/04-DISCUSSION-LOG.md
@@ -1,0 +1,87 @@
+# Phase 04: Provenance Summary - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+>
+> **Retroactive note:** This log was reconstructed on 2026-06-21 from `04-CONTEXT.md`, `04-01-PLAN.md`, `04-02-PLAN.md`, and plan summaries after the original discussion log was found missing.
+
+**Date:** 2026-06-19
+**Phase:** 04-provenance-summary
+**Areas discussed:** Provenance semantics, shared derivation, output behavior, deferred audit detail
+
+---
+
+## Provenance Semantics
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Config-selected primary label | Tools selected by the current config or wizard run should be labeled `tilde-managed`, with installed/manual/dependency evidence preserved as detail. | ✓ |
+| Installation-source primary label | Already installed, dependency, manual, and OS evidence should take primary label precedence even when selected by tilde. | |
+| Scanner-only provenance | Use scanner evidence without config intent to assign primary categories. | |
+
+**User's choice:** Config-selected primary label.
+**Notes:** Captured in `04-CONTEXT.md`: selected tools keep `tilde-managed` as the primary label; detail/action text explains installed, dependency, manual, or unknown evidence.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Preserve dependency evidence | Homebrew dependency remains explicit evidence and detail, including for selected tools. | ✓ |
+| Collapse into installed | Treat dependency installs as generic already-installed tools. | |
+| Promote to direct install | Convert dependency-installed selected tools into direct install intent. | |
+
+**User's choice:** Preserve dependency evidence.
+**Notes:** Selected dependency-installed tools read as selected and already present as a dependency; no install needed unless future logic promotes direct install.
+
+---
+
+## Shared Derivation
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Shared helper | Add a shared provenance helper separate from UI components, deriving labels and actions from config, metadata, and inventory evidence. | ✓ |
+| UI-local logic | Let each UI surface derive its own provenance text. | |
+| Scanner-owned labels | Push final provenance labels into inventory scanning. | |
+
+**User's choice:** Shared helper.
+**Notes:** Captured as `deriveInventoryProvenance(report, config?)`, `summarizeProvenanceGroups()`, and `formatProvenanceSummaryLine()` in Plan 04-01.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Preserve structured evidence | Keep detailed evidence in data structures for tests/future audit views while normal output stays concise. | ✓ |
+| Text-only summaries | Emit only user-facing strings and drop detailed evidence from provenance results. | |
+| Full audit UI now | Add a verbose evidence screen in Phase 04. | |
+
+**User's choice:** Preserve structured evidence.
+**Notes:** The verbose audit view was explicitly deferred.
+
+---
+
+## Output Behavior
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| One concise grouped line | Render one provenance summary line with grouped counts, up to three examples per group, and `+N more`. | ✓ |
+| Verbose per-tool output | Show each tool and evidence item in normal setup output. | |
+| No user-facing output yet | Keep provenance derivation internal until a later UI phase. | |
+
+**User's choice:** One concise grouped line.
+**Notes:** Config-first and final wizard confirmation use shared `summarizeInventory(report, config?)`; early wizard inventory stays evidence-oriented because final selections are not known yet.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Action-oriented explanations | Explain install, skip-present, leave-unmanaged, dependency-present, and cautious unknown outcomes. | ✓ |
+| Category names only | Show labels without action context. | |
+| Block unknowns | Treat unknown selected tools as blockers. | |
+
+**User's choice:** Action-oriented explanations.
+**Notes:** Unknown selected tools do not block apply; warnings remain visible.
+
+---
+
+## the agent's Discretion
+
+- Exact helper shape and tests were delegated to the planner/executor, constrained by the context decisions.
+- Exact summary line wording was left flexible as long as it stayed concise and grouped.
+
+## Deferred Ideas
+
+- Verbose audit view for detailed provenance evidence — future phase.

--- a/.planning/phases/04-provenance-summary/04-VERIFICATION.md
+++ b/.planning/phases/04-provenance-summary/04-VERIFICATION.md
@@ -1,0 +1,41 @@
+# Phase 04: Provenance Summary - Verification
+
+> **Retroactive note:** This verification record was reconstructed on 2026-06-21 from `04-01-SUMMARY.md`, `04-02-SUMMARY.md`, `04-VALIDATION.md`, and `04-REVIEW.md` after the phase-level verification file was found missing.
+
+## Result
+
+Verified retroactively from recorded plan summaries and review artifacts.
+
+## Requirements Checked
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| PROV-01 | `04-01-SUMMARY.md` records tested labels for `tilde-managed`, `already-installed`, `homebrew-dependency`, `manual-install`, `manual-gui`, `os-provided`, and `unknown`. | Pass |
+| PROV-02 | `04-02-SUMMARY.md` records one concise `Provenance:` line in config-first and wizard confirmation output. | Pass |
+| PROV-03 | `04-01-SUMMARY.md` and `04-02-SUMMARY.md` record action/detail text for selected, installed, dependency-present, unmanaged, and unknown paths. | Pass |
+| PROV-04 | `04-REVIEW.md` records clean review of shared derivation via `src/inventory/provenance.ts` and shared rendering through `summarizeInventory()`. | Pass |
+
+## Recorded Verification Commands
+
+From `04-01-SUMMARY.md`:
+
+- `npm run test -- tests/unit/inventory-provenance.test.ts` - passed
+- `npm run build` - passed
+
+From `04-02-SUMMARY.md`:
+
+- `npm run test:integration -- tests/integration/config-first.test.ts tests/integration/wizard-flow.test.tsx -t inventory` - passed
+- `npm run test -- tests/unit/inventory-provenance.test.ts tests/unit/inventory-scanner.test.ts` - passed
+- `npm run build` - passed
+
+From `04-REVIEW.md`:
+
+- `npm test` - passed
+- `npm run test:integration` - passed
+- `npm run build` - passed
+- `npm run lint` - passed
+
+## Notes
+
+- This file does not claim a fresh rerun on 2026-06-21; it records the verification evidence already captured when Phase 04 was completed.
+- Phase 04 review result was clean, with no correctness, security, or maintainability findings requiring changes.

--- a/.planning/phases/06-stabilization-and-config-selection-polish/06-DISCUSSION-LOG.md
+++ b/.planning/phases/06-stabilization-and-config-selection-polish/06-DISCUSSION-LOG.md
@@ -1,0 +1,63 @@
+# Phase 06: Stabilization and Config Selection Polish - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+>
+> **Retroactive note:** This log was reconstructed on 2026-06-21 from `06-CONTEXT.md`, `06-01-PLAN.md`, and `06-01-SUMMARY.md` after the original discussion log was found missing.
+
+**Date:** 2026-06-21
+**Phase:** 06-stabilization-and-config-selection-polish
+**Areas discussed:** Generated JS output, plugin ownership labels, discovered config prompts
+
+---
+
+## Generated JS Output
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Reproduce first | Begin by reproducing and pinning the generated JS/package output issue before changing build behavior. | ✓ |
+| Reconfigure build immediately | Change TypeScript/package config based on the issue title without a failing check. | |
+| Defer build cleanup | Leave artifact behavior for a future packaging phase. | |
+
+**User's choice:** Reproduce first.
+**Notes:** `06-CONTEXT.md` recorded the issue as underspecified and required a failing test or scripted check before changing build behavior.
+
+---
+
+## Plugin Ownership Labels
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Explain first-party ownership | Keep machine-readable plugin source values, but make user-facing output explain built-in ownership. | ✓ |
+| Redesign plugin registry | Widen registry semantics across browser/editor/AI metadata now. | |
+| Leave source label as-is | Keep output like `homebrew  1.0.0  first-party` without clarification. | |
+
+**User's choice:** Explain first-party ownership.
+**Notes:** Phase 06 fixed user-facing output as `first-party (built in)` while preserving machine-readable source values in code.
+
+---
+
+## Discovered Config Prompts
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Prompt/explain discovered configs | Interactive startup/config-first flows confirm or explain auto-discovered config use when no explicit source was provided. | ✓ |
+| Prompt every config source | Ask even when `--config`, `TILDE_CONFIG`, or positional paths are explicit. | |
+| Never prompt | Keep discovered config use implicit. | |
+
+**User's choice:** Prompt/explain discovered configs.
+**Notes:** Explicit config sources bypass the prompt. Non-interactive config-required commands remain deterministic.
+
+---
+
+## the agent's Discretion
+
+- Exact artifact check shape was left to the planner, as long as it was deterministic and user-facing.
+- Exact plugin-list formatting was left flexible, constrained by explainability and compatibility.
+- Exact layer for discovered-config confirmation was left to implementation, constrained by preserving non-interactive behavior.
+
+## Deferred Ideas
+
+- Broader schema versioning moved to Phase 07.
+- Search wrapper and broader registry/search UX moved to Phase 08/09.
+- Build cleanup remains intentionally narrow; future packaging overhaul may replace it.

--- a/.planning/phases/06-stabilization-and-config-selection-polish/06-PATTERNS.md
+++ b/.planning/phases/06-stabilization-and-config-selection-polish/06-PATTERNS.md
@@ -1,0 +1,29 @@
+# Phase 06: Stabilization and Config Selection Polish - Pattern Map
+
+> **Retroactive note:** This pattern map was reconstructed on 2026-06-21 from `06-CONTEXT.md`, `06-01-PLAN.md`, and `06-01-SUMMARY.md`.
+
+## Files and Roles
+
+| File | Role | Pattern |
+|------|------|---------|
+| `scripts/fix-bin-output.cjs` | build utility | Narrow post-build cleanup script invoked from `npm run build`. |
+| `src/index.tsx` | CLI entry | Subcommand routing, plugin list formatting, config source threading. |
+| `src/app.tsx` | app mode router | Pass config source into config-first mode without changing non-interactive commands. |
+| `src/modes/config-first.tsx` | interactive config-first UI | Gate discovered config loading behind confirmation; explicit sources load immediately. |
+| `tests/unit/build-output.test.ts` | build regression test | Deterministic artifact layout assertion. |
+| `tests/unit/config-first.test.ts` | Ink/unit behavior test | Confirm source-specific config-first load behavior. |
+| `tests/integration/cli-regression.test.ts` | CLI regression suite | Built CLI behavior and plugin list output. |
+
+## Established Patterns
+
+- Pin underspecified bugs with focused regression tests before changing behavior.
+- Preserve machine-readable internal values while improving user-facing labels.
+- Thread source metadata only as far as the UI needs it.
+- Keep prompts out of deterministic non-interactive subcommand paths.
+- Use narrow build-output cleanup rather than broad packaging redesign when the phase is stabilization.
+
+## Constraints Reinforced
+
+- Preserve NodeNext ESM `.js` imports in source.
+- Keep external commands mocked in tests.
+- Do not broaden Phase 06 into schema versioning, search wrappers, or registry redesign.

--- a/.planning/phases/06-stabilization-and-config-selection-polish/06-RESEARCH.md
+++ b/.planning/phases/06-stabilization-and-config-selection-polish/06-RESEARCH.md
@@ -1,0 +1,34 @@
+# Phase 06: Stabilization and Config Selection Polish - Research
+
+> **Retroactive note:** This research artifact was reconstructed on 2026-06-21 from `06-CONTEXT.md`, `06-01-PLAN.md`, and `06-01-SUMMARY.md`. No separate research artifact existed during the original Phase 06 execution.
+
+## Research Questions
+
+1. How should the build artifact issue be safely reproduced before changing output?
+2. How can plugin ownership be made explainable without widening registry scope?
+3. Where should discovered-config confirmation live so explicit and non-interactive flows do not regress?
+
+## Findings
+
+### Build Output
+
+- `package.json` originally used `tsc && tsc -p tsconfig.bin.json`.
+- `tsconfig.bin.json` includes `bin/tilde.ts` plus imported source, which caused duplicated compiled source under `dist/src`.
+- The selected fix was intentionally narrow: keep source imports stable and post-process emitted bin output so the package binary imports `dist/index.js`, then remove duplicate `dist/src`.
+- A future packaging overhaul may replace this with a cleaner bin-specific build pipeline.
+
+### Plugin Ownership
+
+- `TildePlugin.source` remains useful as a machine-readable source value.
+- The user-facing problem was ambiguity, not the need for a broad registry redesign.
+- Output can explain `first-party` as built in without expanding browser/editor/AI registry semantics in Phase 06.
+
+### Discovered Config Confirmation
+
+- Existing config resolution already distinguished `flag`, `env`, `positional`, and `discovered` sources.
+- Confirmation belongs in the interactive config-first/startup path, not non-interactive subcommands.
+- Explicit `--config`, `TILDE_CONFIG`, and positional paths should bypass discovery prompts.
+
+## Recommendation
+
+Keep Phase 06 as stabilization only: targeted tests first, narrow implementation fixes, no schema/search expansion, and no broad plugin registry redesign.

--- a/.planning/phases/06-stabilization-and-config-selection-polish/06-REVIEW.md
+++ b/.planning/phases/06-stabilization-and-config-selection-polish/06-REVIEW.md
@@ -1,0 +1,30 @@
+# Phase 06: Stabilization and Config Selection Polish - Review
+
+> **Retroactive note:** This review artifact was reconstructed on 2026-06-21 from `06-01-SUMMARY.md`. It records the review outcome implied by completed verification, not a fresh code review rerun.
+
+## Result
+
+No open findings recorded in the completed Phase 06 summary.
+
+## Review Scope
+
+- Build output cleanup and generated artifact regression coverage.
+- Plugin list ownership/source output.
+- Discovered-config confirmation behavior for interactive config-first startup.
+- Explicit config source bypass behavior.
+
+## Risk Notes
+
+- The build cleanup script is intentionally narrow; a future packaging overhaul may replace it.
+- Prompt behavior must remain limited to interactive discovered-config flows.
+- Plugin ownership formatting should not become a broad registry/search redesign.
+
+## Verification Context
+
+Recorded in `06-01-SUMMARY.md`:
+
+- `npm run build` - passed
+- `npm run test -- tests/unit/build-output.test.ts` - passed after build cleanup
+- `npm run test:integration -- tests/integration/cli-regression.test.ts` - passed, 22 tests and 1 existing todo
+- `npm run test -- tests/unit/config-first.test.ts tests/unit/build-output.test.ts` - passed, 6 tests
+- `npm run test -- tests/unit/config-discovery.test.ts tests/unit/tool-metadata.test.ts tests/unit/config-first.test.ts tests/unit/build-output.test.ts` - passed, 56 tests

--- a/.planning/phases/06-stabilization-and-config-selection-polish/06-VALIDATION.md
+++ b/.planning/phases/06-stabilization-and-config-selection-polish/06-VALIDATION.md
@@ -1,0 +1,31 @@
+# Phase 06: Stabilization and Config Selection Polish - Validation Strategy
+
+> **Retroactive note:** This validation artifact was reconstructed on 2026-06-21 from `06-01-PLAN.md` and `06-01-SUMMARY.md`.
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| Framework | Vitest |
+| Unit config | `vitest.config.ts` |
+| Integration config | `vitest.integration.config.ts` |
+| Build command | `npm run build` |
+
+## Validation Map
+
+| Requirement | Target Behavior | Automated Command | Recorded Status |
+|-------------|-----------------|-------------------|-----------------|
+| STAB-01 | Generated runtime output imports `dist/index.js` and does not rely on duplicated `dist/src`. | `npm run build`; `npm run test -- tests/unit/build-output.test.ts` | Passed |
+| STAB-02 | `tilde plugin list` explains first-party ownership as built in. | `npm run test:integration -- tests/integration/cli-regression.test.ts` | Passed |
+| STAB-03 | Discovered configs are confirmed before config-first loading, while explicit sources bypass prompting. | `npm run test -- tests/unit/config-first.test.ts` | Passed |
+| Regression guard | Existing discovery and metadata tests stay green. | `npm run test -- tests/unit/config-discovery.test.ts tests/unit/tool-metadata.test.ts tests/unit/config-first.test.ts tests/unit/build-output.test.ts` | Passed |
+
+## Sampling Strategy
+
+- Run targeted unit tests after source-level changes.
+- Run CLI regression tests after changing CLI output or build output behavior.
+- Run `npm run build` after build pipeline changes.
+
+## Sign-Off
+
+Recorded verification in `06-01-SUMMARY.md` satisfies the validation map for STAB-01, STAB-02, and STAB-03.

--- a/.planning/phases/06-stabilization-and-config-selection-polish/06-VERIFICATION.md
+++ b/.planning/phases/06-stabilization-and-config-selection-polish/06-VERIFICATION.md
@@ -1,0 +1,28 @@
+# Phase 06: Stabilization and Config Selection Polish - Verification
+
+> **Retroactive note:** This verification record was reconstructed on 2026-06-21 from `06-01-SUMMARY.md` after the phase-level verification file was found missing.
+
+## Result
+
+Verified retroactively from the completed plan summary.
+
+## Requirements Checked
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| STAB-01 | `06-01-SUMMARY.md` records build-output regression coverage and post-build cleanup. | Pass |
+| STAB-02 | `06-01-SUMMARY.md` records `tilde plugin list` output changed to `first-party (built in)` with CLI regression coverage. | Pass |
+| STAB-03 | `06-01-SUMMARY.md` records discovered-config confirmation and explicit-source bypass coverage. | Pass |
+
+## Recorded Verification Commands
+
+- `npm run build` - passed
+- `npm run test -- tests/unit/build-output.test.ts` - passed after build cleanup
+- `npm run test:integration -- tests/integration/cli-regression.test.ts` - passed, 22 tests and 1 existing todo
+- `npm run test -- tests/unit/config-first.test.ts tests/unit/build-output.test.ts` - passed, 6 tests
+- `npm run test -- tests/unit/config-discovery.test.ts tests/unit/tool-metadata.test.ts tests/unit/config-first.test.ts tests/unit/build-output.test.ts` - passed, 56 tests
+
+## Notes
+
+- This file does not claim a fresh rerun on 2026-06-21.
+- The existing CLI invalid-argument todo was recorded as unrelated in the Phase 06 summary.


### PR DESCRIPTION
## Summary

Backfills missing GSD planning/discussion artifacts for prior phases:

- Phase 04: discussion log and verification record
- Phase 06: discussion log, research, pattern map, review, validation, and verification records

Each new artifact is explicitly marked as retroactively reconstructed and cites the existing source artifacts used for reconstruction.

## Release workflow note

I checked release packaging because `.planning` was mentioned. The package already uses `package.json` `files: ["dist", "bootstrap.sh"]`, so `.planning` is already excluded from npm release artifacts. No release workflow change is included.

## Validation

- `npm pack --dry-run --json` confirmed the package file list does not include `.planning/`.
- No code changes were made; runtime tests were not rerun for this docs-only backfill.

## Local note

Local `gh` auth is currently invalid, so this branch/PR was created through the GitHub connector rather than `git push`/`gh pr create`.